### PR TITLE
Register screen implementation with backend connection/ feature/student-registration-frontend-issue-#1

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,9 @@
       "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\andre\\\\OneDrive\\\\Documents\\\\Univesidad\\\\Cuarto año\\\\Movile\\\\Proyecto\\\\JobMatch-frontend\" -Recurse -Directory)",
       "Bash(Select-Object -First 20)",
       "Bash(Format-Table FullName)",
-      "Bash(./gradlew assembleDebug)"
+      "Bash(./gradlew assembleDebug)",
+      "Bash(Select-Object FullName)",
+      "Bash(Sort-Object FullName)"
     ]
   }
 }

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,56 +1,12 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
     <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="MultiplatformPreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="MultiplatformPreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
   </profile>
 </component>

--- a/app/src/main/java/com/moviles/jobmatch/core/AppConstants.kt
+++ b/app/src/main/java/com/moviles/jobmatch/core/AppConstants.kt
@@ -9,6 +9,7 @@ object AppConstants {
         object Paths {
             const val COMPANY_PROFILE = "companies/{companyId}"
             const val AUTH_LOGIN = "auth/login"
+            const val AUTH_REGISTER_STUDENT = "auth/register"
         }
     }
 }

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -5,6 +5,8 @@ import com.moviles.jobmatch.data.Company
 import com.moviles.jobmatch.data.CompanySummary
 import com.moviles.jobmatch.data.remote.model.LoginRequest
 import com.moviles.jobmatch.data.remote.model.LoginResponse
+import com.moviles.jobmatch.data.remote.model.RegisterResponse
+import com.moviles.jobmatch.data.remote.model.RegisterStudentRequest
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -14,6 +16,9 @@ import retrofit2.http.Path
 interface ApiService {
     @POST(AppConstants.Api.Paths.AUTH_LOGIN)
     suspend fun login(@Body request: LoginRequest): Response<LoginResponse>
+
+    @POST(AppConstants.Api.Paths.AUTH_REGISTER_STUDENT)
+    suspend fun registerStudent(@Body request: RegisterStudentRequest): Response<RegisterResponse>
 
     @GET("companies/{companyId}")
     suspend fun getCompanyProfile(@Path("companyId") companyId: String): Company

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/AuthModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/AuthModels.kt
@@ -13,3 +13,18 @@ data class LoginResponse(
     val token: String,
     val expiration: String
 )
+
+data class RegisterStudentRequest(
+    val fullName: String,
+    val email: String,
+    @com.google.gson.annotations.SerializedName("passwordHash")
+    val password: String,
+    val university: String,
+    val career: String,
+    val studentId: String? = null
+)
+
+data class RegisterResponse(
+    val userId: String,
+    val message: String
+)

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/AuthRepository.kt
@@ -3,6 +3,8 @@ package com.moviles.jobmatch.data.repository
 import com.moviles.jobmatch.data.remote.ApiService
 import com.moviles.jobmatch.data.remote.model.LoginRequest
 import com.moviles.jobmatch.data.remote.model.LoginResponse
+import com.moviles.jobmatch.data.remote.model.RegisterResponse
+import com.moviles.jobmatch.data.remote.model.RegisterStudentRequest
 import java.io.IOException
 
 class AuthRepository(private val apiService: ApiService) {
@@ -16,6 +18,39 @@ class AuthRepository(private val apiService: ApiService) {
                 }
                 response.code() == 401 -> {
                     ApiResult.Error("Credenciales incorrectas", 401)
+                }
+                response.code() == 400 -> {
+                    ApiResult.Error("Datos inválidos", 400)
+                }
+                else -> {
+                    ApiResult.Error("Error del servidor (${response.code()})", response.code())
+                }
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado")
+        }
+    }
+
+    suspend fun registerStudent(
+        fullName: String,
+        email: String,
+        password: String,
+        university: String,
+        career: String,
+        studentId: String
+    ): ApiResult<RegisterResponse> {
+        return try {
+            val response = apiService.registerStudent(
+                RegisterStudentRequest(fullName, email, password, university, career, studentId)
+            )
+            when {
+                response.isSuccessful && response.body() != null -> {
+                    ApiResult.Success(response.body()!!)
+                }
+                response.code() == 409 -> {
+                    ApiResult.Error("Este correo ya está registrado", 409)
                 }
                 response.code() == 400 -> {
                     ApiResult.Error("Datos inválidos", 400)

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppDestinations.kt
@@ -3,6 +3,7 @@ package com.moviles.jobmatch.navigation
 object AppDestinations {
     const val SPLASH = "splash"
     const val LOGIN = "login"
+    const val REGISTER = "register"
     const val SEARCH_COMPANY = "search_company"
     const val COMPANY_PROFILE = "company_profile/{companyId}"
 

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.moviles.jobmatch.ui.screens.company.CompanyProfileScreen
 import com.moviles.jobmatch.ui.screens.login.LoginScreen
+import com.moviles.jobmatch.ui.screens.register.RegisterScreen
 import com.moviles.jobmatch.ui.screens.search.SearchCompanyScreen
 import com.moviles.jobmatch.ui.screens.splash.SplashScreen
 
@@ -32,8 +33,20 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                         popUpTo(AppDestinations.LOGIN) { inclusive = true }
                     }
                 },
-                onNavigateToRegister = { /* TODO: ruta registro */ },
+                onNavigateToRegister = {
+                    navController.navigate(AppDestinations.REGISTER)
+                },
                 onNavigateToForgotPassword = { /* TODO: ruta recuperar contraseña */ }
+            )
+        }
+
+        composable(route = AppDestinations.REGISTER) {
+            RegisterScreen(
+                onNavigateToLogin = {
+                    navController.navigate(AppDestinations.LOGIN) {
+                        popUpTo(AppDestinations.SPLASH) { inclusive = false }
+                    }
+                }
             )
         }
 

--- a/app/src/main/java/com/moviles/jobmatch/ui/components/AccountTypeCard.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/components/AccountTypeCard.kt
@@ -1,0 +1,104 @@
+package com.moviles.jobmatch.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.moviles.jobmatch.ui.theme.BottomNavUnselected
+import com.moviles.jobmatch.ui.theme.DarkBlue
+
+@Composable
+fun AccountTypeCard(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val borderColor = if (isSelected) DarkBlue else Color.LightGray
+    val backgroundColor = if (isSelected) DarkBlue.copy(alpha = 0.06f) else Color.White
+
+    Box(
+        modifier = modifier
+            .border(
+                width = if (isSelected) 2.dp else 1.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .background(color = backgroundColor, shape = RoundedCornerShape(12.dp))
+            .clickable { onClick() }
+            .padding(12.dp)
+    ) {
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(20.dp)
+                    .background(color = DarkBlue, shape = CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+        }
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .background(
+                        color = if (isSelected) DarkBlue.copy(alpha = 0.12f) else Color(0xFFF5F5F5),
+                        shape = RoundedCornerShape(8.dp)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = if (isSelected) DarkBlue else Color.Gray,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = if (isSelected) DarkBlue else BottomNavUnselected
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.Gray
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/register/RegisterScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/register/RegisterScreen.kt
@@ -1,0 +1,405 @@
+package com.moviles.jobmatch.ui.screens.register
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Badge
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.Work
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
+import com.moviles.jobmatch.data.repository.AppContainer
+import com.moviles.jobmatch.ui.components.AccountTypeCard
+import com.moviles.jobmatch.ui.components.JobMatchButton
+import com.moviles.jobmatch.ui.components.JobMatchTextField
+import com.moviles.jobmatch.ui.theme.Background
+import com.moviles.jobmatch.ui.theme.BottomNavUnselected
+import com.moviles.jobmatch.ui.theme.DarkBlue
+import com.moviles.jobmatch.ui.theme.JobMatchTheme
+import com.moviles.jobmatch.ui.theme.StatusActive
+import com.moviles.jobmatch.ui.theme.StatusInactive
+
+@Composable
+fun RegisterScreen(
+    onNavigateToLogin: () -> Unit = {}
+) {
+    val registerViewModel: RegisterViewModel = viewModel(
+        factory = RegisterViewModelFactory(AppContainer.authRepository)
+    )
+    val uiState by registerViewModel.uiState.collectAsStateWithLifecycle()
+
+    var fullName by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+    var confirmPassword by remember { mutableStateOf("") }
+    var confirmPasswordVisible by remember { mutableStateOf(false) }
+    var university by remember { mutableStateOf("") }
+    var career by remember { mutableStateOf("") }
+    var studentId by remember { mutableStateOf("") }
+
+    LaunchedEffect(uiState.isRegistered) {
+        if (uiState.isRegistered) {
+            delay(1500L)
+            onNavigateToLogin()
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Background)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(48.dp))
+
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .background(color = DarkBlue, shape = CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Work,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(40.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "JobMatch",
+                style = MaterialTheme.typography.titleMedium,
+                color = BottomNavUnselected,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Crear Cuenta",
+                style = MaterialTheme.typography.headlineLarge,
+                color = BottomNavUnselected
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "Únete a la comunidad de JobMatch hoy mismo.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.Gray,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "¿Cómo usarás JobMatch?",
+                style = MaterialTheme.typography.bodyMedium,
+                color = BottomNavUnselected,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                AccountTypeCard(
+                    icon = Icons.Default.School,
+                    title = "Estudiante",
+                    description = "Busco trabajos temporales y pasantías.",
+                    isSelected = true,
+                    onClick = {},
+                    modifier = Modifier.weight(1f)
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    AccountTypeCard(
+                        icon = Icons.Default.Work,
+                        title = "Empresa",
+                        description = "Busco talento joven para mi negocio.",
+                        isSelected = false,
+                        onClick = {},
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .alpha(0.4f)
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Próximamente",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = Color.Gray,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            JobMatchTextField(
+                value = fullName,
+                onValueChange = { fullName = it },
+                label = "Nombre Completo",
+                placeholder = "Ej. Juan Pérez",
+                leadingIcon = Icons.Default.Person
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            JobMatchTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = "Correo Electrónico",
+                placeholder = "nombre@ejemplo.com",
+                leadingIcon = Icons.Default.Email,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            JobMatchTextField(
+                value = university,
+                onValueChange = { university = it },
+                label = "Universidad",
+                placeholder = "Ej. Universidad de Costa Rica",
+                leadingIcon = Icons.Default.School
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            JobMatchTextField(
+                value = career,
+                onValueChange = { career = it },
+                label = "Carrera",
+                placeholder = "Ej. Ingeniería en Sistemas",
+                leadingIcon = Icons.AutoMirrored.Filled.MenuBook
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            JobMatchTextField(
+                value = studentId,
+                onValueChange = { studentId = it },
+                label = "Cédula",
+                placeholder = "Ej. 118340123",
+                leadingIcon = Icons.Default.Badge
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            JobMatchTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = "Contraseña",
+                placeholder = "••••••••",
+                leadingIcon = Icons.Default.Lock,
+                visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                trailingIcon = {
+                    IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                        Icon(
+                            imageVector = if (passwordVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff,
+                            contentDescription = if (passwordVisible) "Ocultar" else "Mostrar",
+                            tint = Color.Gray
+                        )
+                    }
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            JobMatchTextField(
+                value = confirmPassword,
+                onValueChange = { confirmPassword = it },
+                label = "Confirmar Contraseña",
+                placeholder = "••••••••",
+                leadingIcon = Icons.Default.Lock,
+                visualTransformation = if (confirmPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                trailingIcon = {
+                    IconButton(onClick = { confirmPasswordVisible = !confirmPasswordVisible }) {
+                        Icon(
+                            imageVector = if (confirmPasswordVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff,
+                            contentDescription = if (confirmPasswordVisible) "Ocultar" else "Mostrar",
+                            tint = Color.Gray
+                        )
+                    }
+                }
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            val isFormValid = fullName.isNotBlank() && email.isNotBlank() &&
+                university.isNotBlank() && career.isNotBlank() && studentId.isNotBlank() &&
+                password.isNotBlank() && confirmPassword.isNotBlank()
+
+            Button(
+                onClick = {
+                    registerViewModel.register(
+                        fullName, email, password, confirmPassword,
+                        university, career, studentId.ifBlank { null }
+                    )
+                },
+                enabled = !uiState.isLoading,
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = DarkBlue,
+                    contentColor = Color.White,
+                    disabledContainerColor = DarkBlue.copy(alpha = 0.5f),
+                    disabledContentColor = Color.White.copy(alpha = 0.7f)
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(52.dp)
+            ) {
+                Text(
+                    text = "Registrarse",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp
+                )
+            }
+
+            if (uiState.successMessage != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = uiState.successMessage!!,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = StatusActive,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            if (uiState.errorMessage != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = uiState.errorMessage!!,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = StatusInactive,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = "¿Ya tienes una cuenta? ",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = BottomNavUnselected
+                )
+                Text(
+                    text = "Iniciar sesión",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = DarkBlue,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.clickable { onNavigateToLogin() }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = buildAnnotatedString {
+                    append("Al registrarte, aceptas nuestros ")
+                    withStyle(SpanStyle(color = DarkBlue)) {
+                        append("Términos de Servicio")
+                    }
+                    append(" y ")
+                    withStyle(SpanStyle(color = DarkBlue)) {
+                        append("Política de Privacidad")
+                    }
+                    append(".")
+                },
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 8.dp)
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+
+        if (uiState.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.3f)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = DarkBlue)
+            }
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    showSystemUi = true
+)
+@Composable
+fun RegisterScreenPreview() {
+    JobMatchTheme {
+        RegisterScreen()
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/register/RegisterViewModel.kt
@@ -1,0 +1,84 @@
+package com.moviles.jobmatch.ui.screens.register
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.moviles.jobmatch.data.repository.ApiResult
+import com.moviles.jobmatch.data.repository.AuthRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class RegisterUiState(
+    val isLoading: Boolean = false,
+    val isRegistered: Boolean = false,
+    val successMessage: String? = null,
+    val errorMessage: String? = null
+)
+
+class RegisterViewModel(private val authRepository: AuthRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RegisterUiState())
+    val uiState: StateFlow<RegisterUiState> = _uiState.asStateFlow()
+
+    fun register(
+        fullName: String,
+        email: String,
+        password: String,
+        confirmPassword: String,
+        university: String,
+        career: String,
+        studentId: String?
+    ) {
+        if (fullName.isBlank() || email.isBlank() || password.isBlank() ||
+            confirmPassword.isBlank() || university.isBlank() || career.isBlank() || studentId.isNullOrBlank()
+        ) {
+            _uiState.update { it.copy(errorMessage = "Por favor completa todos los campos") }
+            return
+        }
+
+        if (password != confirmPassword) {
+            _uiState.update { it.copy(errorMessage = "Las contraseñas no coinciden") }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+
+            when (val result = authRepository.registerStudent(
+                fullName, email, password, university, career, studentId
+            )) {
+                is ApiResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            isRegistered = true,
+                            successMessage = "¡Cuenta creada exitosamente! Inicia sesión."
+                        )
+                    }
+                }
+                is ApiResult.Error -> {
+                    _uiState.update { it.copy(isLoading = false, errorMessage = result.message) }
+                }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+}
+
+class RegisterViewModelFactory(
+    private val authRepository: AuthRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(RegisterViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return RegisterViewModel(authRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}


### PR DESCRIPTION
Implements the full Register screen for student accounts, connected to the backend using the same MVVM + Repository Pattern architecture as the Login.

### **New files added:**
- ui/components/AccountTypeCard.kt: reusable selectable card component for account type selection (Student/Company)
- ui/screens/register/RegisterScreen.kt: full register screen with account type selector, form fields and navigation
- ui/screens/register/RegisterViewModel.kt: ViewModel with RegisterUiState managing loading, success and error states using isRegistered boolean flag instead of userId to trigger navigation

### **Modified files:**
- data/remote/model/AuthModels.kt: added RegisterStudentRequest with @SerializedName("passwordHash") annotation and RegisterResponse model
- core/AppConstants.kt: added AUTH_REGISTER_STUDENT path constant
- data/remote/ApiService.kt: added registerStudent() endpoint definition
- data/repository/AuthRepository.kt: added registerStudent() with error handling for 409 (email already registered), 400 (invalid data) and network failures
- data/repository/AppContainer.kt: authRepository already available from Login implementation
- navigation/AppDestinations.kt: added REGISTER = "register"
- navigation/AppNavHost.kt: added composable for REGISTER route with navigation back to LOGIN clearing the backstack up to SPLASH

The register flow validates empty fields and matching passwords on the frontend before making the network call. On success it shows a confirmation message for 1.5 seconds then navigates to Login. The Company account type is visually disabled as it is not implemented yet.