### PR TITLE
View application details

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/core/AppConstants.kt
+++ b/app/src/main/java/com/moviles/jobmatch/core/AppConstants.kt
@@ -3,7 +3,7 @@ package com.moviles.jobmatch.core
 
 object AppConstants {
 
-    const val BASE_URL = "http://10.0.2.2:5293/"
+    const val BASE_URL = "http://localhost:5293/"
 
     object Api {
         object Paths {

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppDestinations.kt
@@ -18,6 +18,22 @@ object AppDestinations {
     const val ALERTS = "alertas"
     const val PROFILE = "perfil"
     const val STUDENT_PROFILE = "student_profile"
+    const val STUDENT_PUBLIC_PROFILE = "student_public_profile"
+    const val APPLICATION_DETAIL = "application_detail"
+
+    fun applicationDetailRoute(
+        applicationId: Int,
+        jobId: Int,
+        jobTitle: String,
+        studentId: String,
+        studentName: String,
+        studentEmail: String,
+        status: String,
+        createdAt: String
+    ): String = "$APPLICATION_DETAIL/$applicationId/$jobId/${Uri.encode(jobTitle)}/${Uri.encode(studentId)}/${Uri.encode(studentName)}/${Uri.encode(studentEmail)}/${Uri.encode(status)}/${Uri.encode(createdAt)}"
+
+    fun studentPublicProfileRoute(studentId: String): String =
+        "$STUDENT_PUBLIC_PROFILE/${Uri.encode(studentId)}"
 
     fun companyProfileRoute(companyId: String): String {
         return "$COMPANY_PROFILE/${Uri.encode(companyId)}"

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
@@ -24,8 +24,10 @@ import com.moviles.jobmatch.ui.screens.company.CompanyDashboardScreen
 import com.moviles.jobmatch.ui.screens.company.CompanyJobsScreen
 import com.moviles.jobmatch.ui.screens.company.CompanyProfileScreen
 import com.moviles.jobmatch.ui.screens.company.CreateJobScreen
+import com.moviles.jobmatch.ui.screens.job.ApplicationDetailScreen
 import com.moviles.jobmatch.ui.screens.job.ApplicationsScreen
 import com.moviles.jobmatch.ui.screens.job.EditJobScreen
+import com.moviles.jobmatch.ui.screens.profile.StudentPublicProfileScreen
 import com.moviles.jobmatch.ui.screens.job.JobDetailScreen
 import com.moviles.jobmatch.ui.screens.job.JobsScreen
 import com.moviles.jobmatch.ui.screens.job.JobsViewModel
@@ -50,7 +52,9 @@ fun AppNavHost(modifier: Modifier = Modifier) {
             currentRoute != AppDestinations.REGISTER &&
             currentRoute?.startsWith(AppDestinations.JOB_DETAIL) != true &&
             currentRoute?.startsWith(AppDestinations.EDIT_JOB) != true &&
-            currentRoute?.startsWith(AppDestinations.APPLICATIONS) != true
+            currentRoute?.startsWith(AppDestinations.APPLICATIONS) != true &&
+            currentRoute?.startsWith(AppDestinations.STUDENT_PUBLIC_PROFILE) != true &&
+            currentRoute?.startsWith(AppDestinations.APPLICATION_DETAIL) != true
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -250,6 +254,63 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                 ApplicationsScreen(
                     jobId = jobId,
                     jobTitle = jobTitle,
+                    onBackPressed = { navController.popBackStack() },
+                    onStudentClick = { studentId ->
+                        navController.navigate(AppDestinations.studentPublicProfileRoute(studentId))
+                    },
+                    onViewApplicationDetail = { application, jId ->
+                        navController.navigate(
+                            AppDestinations.applicationDetailRoute(
+                                applicationId = application.idApplication,
+                                jobId = jId,
+                                jobTitle = application.jobTitle,
+                                studentId = application.idStudent,
+                                studentName = application.studentName,
+                                studentEmail = application.studentEmail,
+                                status = application.status,
+                                createdAt = application.createdAt
+                            )
+                        )
+                    }
+                )
+            }
+            composable(
+                route = "${AppDestinations.APPLICATION_DETAIL}/{applicationId}/{jobId}/{jobTitle}/{studentId}/{studentName}/{studentEmail}/{status}/{createdAt}",
+                arguments = listOf(
+                    navArgument("applicationId") { type = NavType.IntType },
+                    navArgument("jobId") { type = NavType.IntType },
+                    navArgument("jobTitle") { type = NavType.StringType },
+                    navArgument("studentId") { type = NavType.StringType },
+                    navArgument("studentName") { type = NavType.StringType },
+                    navArgument("studentEmail") { type = NavType.StringType },
+                    navArgument("status") { type = NavType.StringType },
+                    navArgument("createdAt") { type = NavType.StringType }
+                )
+            ) { backStackEntry ->
+                val args = backStackEntry.arguments!!
+                ApplicationDetailScreen(
+                    applicationId = args.getInt("applicationId"),
+                    jobId = args.getInt("jobId"),
+                    jobTitle = args.getString("jobTitle").orEmpty(),
+                    studentId = args.getString("studentId").orEmpty(),
+                    studentName = args.getString("studentName").orEmpty(),
+                    studentEmail = args.getString("studentEmail").orEmpty(),
+                    status = args.getString("status").orEmpty(),
+                    createdAt = args.getString("createdAt").orEmpty(),
+                    onBackPressed = { navController.popBackStack() },
+                    onViewStudentProfile = { studentId ->
+                        navController.navigate(AppDestinations.studentPublicProfileRoute(studentId))
+                    }
+                )
+            }
+
+            composable(
+                route = "${AppDestinations.STUDENT_PUBLIC_PROFILE}/{studentId}",
+                arguments = listOf(navArgument("studentId") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val studentId = backStackEntry.arguments?.getString("studentId").orEmpty()
+                StudentPublicProfileScreen(
+                    studentId = studentId,
                     onBackPressed = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
@@ -287,7 +287,7 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                     navArgument("createdAt") { type = NavType.StringType }
                 )
             ) { backStackEntry ->
-                val args = backStackEntry.arguments!!
+                val args = backStackEntry.arguments ?: return@composable
                 ApplicationDetailScreen(
                     applicationId = args.getInt("applicationId"),
                     jobId = args.getInt("jobId"),

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/job/ApplicationDetailScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/job/ApplicationDetailScreen.kt
@@ -1,0 +1,163 @@
+package com.moviles.jobmatch.ui.screens.job
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.moviles.jobmatch.ui.theme.DarkBlue
+import com.moviles.jobmatch.ui.utils.formatApplicationDate
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApplicationDetailScreen(
+    applicationId: Int,
+    jobId: Int,
+    jobTitle: String,
+    studentId: String,
+    studentName: String,
+    studentEmail: String,
+    status: String,
+    createdAt: String,
+    onBackPressed: () -> Unit = {},
+    onViewStudentProfile: (String) -> Unit = {}
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Detalle de Postulación", fontWeight = FontWeight.SemiBold) },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Volver")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
+            )
+        },
+        containerColor = Color(0xFFF5F7FA)
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Status banner
+            val (bgColor, textColor, label) = when (status.lowercase()) {
+                "accepted" -> Triple(Color(0xFFE8F5E9), Color(0xFF2E7D32), "Aceptado")
+                "rejected" -> Triple(Color(0xFFFFEBEE), Color(0xFFC62828), "Rechazado")
+                else -> Triple(Color(0xFFFFF8E1), Color(0xFFF57F17), "Pendiente")
+            }
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = bgColor),
+                elevation = CardDefaults.cardElevation(0.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Icon(Icons.Outlined.Info, null, tint = textColor, modifier = Modifier.size(20.dp))
+                    Text(
+                        text = "Estado: $label",
+                        fontWeight = FontWeight.SemiBold,
+                        color = textColor,
+                        fontSize = 15.sp
+                    )
+                }
+            }
+
+            // Datos de la postulación
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White),
+                elevation = CardDefaults.cardElevation(2.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    Text(
+                        "Información de la Postulación",
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 13.sp,
+                        color = Color(0xFF8A9BB0)
+                    )
+                    DetailRow(icon = Icons.Outlined.Tag, label = "ID Postulación", value = "#$applicationId")
+                    DetailRow(icon = Icons.Outlined.Work, label = "ID Trabajo", value = "#$jobId")
+                    DetailRow(icon = Icons.Outlined.WorkOutline, label = "Puesto", value = jobTitle)
+                    DetailRow(icon = Icons.Outlined.Badge, label = "ID Estudiante", value = studentId)
+                    DetailRow(
+                        icon = Icons.Outlined.CalendarToday,
+                        label = "Fecha de postulación",
+                        value = formatApplicationDate(createdAt)
+                    )
+                }
+            }
+
+            // Datos del estudiante
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White),
+                elevation = CardDefaults.cardElevation(2.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(14.dp)
+                ) {
+                    Text(
+                        "Estudiante",
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 13.sp,
+                        color = Color(0xFF8A9BB0)
+                    )
+                    DetailRow(icon = Icons.Outlined.Person, label = "Nombre", value = studentName)
+                    DetailRow(icon = Icons.Outlined.Email, label = "Correo", value = studentEmail)
+                }
+            }
+
+            // Botón ver perfil completo
+            Button(
+                onClick = { onViewStudentProfile(studentId) },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = DarkBlue)
+            ) {
+                Icon(Icons.Outlined.Person, null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Ver perfil completo del estudiante", fontSize = 14.sp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(icon: ImageVector, label: String, value: String) {
+    Row(
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(icon, null, tint = DarkBlue, modifier = Modifier.size(18.dp).padding(top = 2.dp))
+        Column {
+            Text(label, fontSize = 11.sp, color = Color(0xFF8A9BB0))
+            Text(value, fontSize = 14.sp, fontWeight = FontWeight.Medium, color = Color(0xFF1A1A2E))
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/job/ApplicationDetailScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/job/ApplicationDetailScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -39,7 +39,7 @@ fun ApplicationDetailScreen(
                 title = { Text("Detalle de Postulación", fontWeight = FontWeight.SemiBold) },
                 navigationIcon = {
                     IconButton(onClick = onBackPressed) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Volver")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
@@ -55,7 +55,7 @@ fun ApplicationDetailScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            // Status banner
+            // Status banner (color-coded by state)
             val (bgColor, textColor, label) = when (status.lowercase()) {
                 "accepted" -> Triple(Color(0xFFE8F5E9), Color(0xFF2E7D32), "Aceptado")
                 "rejected" -> Triple(Color(0xFFFFEBEE), Color(0xFFC62828), "Rechazado")
@@ -82,7 +82,7 @@ fun ApplicationDetailScreen(
                 }
             }
 
-            // Datos de la postulación
+            // Application details
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
@@ -111,7 +111,7 @@ fun ApplicationDetailScreen(
                 }
             }
 
-            // Datos del estudiante
+            // Student data
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(16.dp),
@@ -133,7 +133,7 @@ fun ApplicationDetailScreen(
                 }
             }
 
-            // Botón ver perfil completo
+            // View full profile button
             Button(
                 onClick = { onViewStudentProfile(studentId) },
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/job/ApplicationsScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/job/ApplicationsScreen.kt
@@ -1,6 +1,7 @@
 package com.moviles.jobmatch.ui.screens.job
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -10,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.CalendarToday
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -27,6 +29,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.remote.model.ApplicationResponse
 import com.moviles.jobmatch.ui.components.SkillChip
 import com.moviles.jobmatch.ui.theme.DarkBlue
+import com.moviles.jobmatch.ui.utils.formatApplicationDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -34,6 +37,8 @@ fun ApplicationsScreen(
     jobId: Int,
     jobTitle: String,
     onBackPressed: () -> Unit = {},
+    onStudentClick: (String) -> Unit = {},
+    onViewApplicationDetail: (ApplicationResponse, Int) -> Unit = { _, _ -> },
     viewModel: ApplicationsViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -108,7 +113,9 @@ fun ApplicationsScreen(
                             application = application,
                             isUpdating = uiState.updatingId == application.idApplication,
                             onAccept = { viewModel.updateStatus(application.idApplication, "accepted") },
-                            onReject = { viewModel.updateStatus(application.idApplication, "rejected") }
+                            onReject = { viewModel.updateStatus(application.idApplication, "rejected") },
+                            onStudentClick = { onStudentClick(application.idStudent) },
+                            onViewDetail = { onViewApplicationDetail(application, jobId) }
                         )
                     }
                 }
@@ -122,7 +129,9 @@ private fun ApplicantCard(
     application: ApplicationResponse,
     isUpdating: Boolean,
     onAccept: () -> Unit,
-    onReject: () -> Unit
+    onReject: () -> Unit,
+    onStudentClick: () -> Unit = {},
+    onViewDetail: () -> Unit = {}
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -131,7 +140,12 @@ private fun ApplicantCard(
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .clickable(onClick = onStudentClick)
+                    .padding(vertical = 4.dp)
+            ) {
                 Box(
                     modifier = Modifier
                         .size(46.dp)
@@ -154,7 +168,7 @@ private fun ApplicantCard(
                         text = application.studentName,
                         fontWeight = FontWeight.SemiBold,
                         fontSize = 15.sp,
-                        color = Color(0xFF1A1A2E)
+                        color = DarkBlue
                     )
                     Text(
                         text = application.studentEmail,
@@ -190,6 +204,35 @@ private fun ApplicantCard(
                         )
                     }
                 }
+            }
+
+            Spacer(modifier = Modifier.height(10.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Icon(
+                    Icons.Outlined.CalendarToday,
+                    contentDescription = null,
+                    modifier = Modifier.size(12.dp),
+                    tint = Color.Gray
+                )
+                Text(
+                    text = "Postulado el ${formatApplicationDate(application.createdAt)}",
+                    fontSize = 11.sp,
+                    color = Color.Gray
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = onViewDetail,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(10.dp),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = DarkBlue),
+                border = androidx.compose.foundation.BorderStroke(1.dp, DarkBlue)
+            ) {
+                Text("Ver detalle de la postulación", fontSize = 13.sp)
             }
 
             if (application.status.lowercase() == "pending") {

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentPublicProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentPublicProfileScreen.kt
@@ -1,0 +1,267 @@
+package com.moviles.jobmatch.ui.screens.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.outlined.School
+import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material.icons.outlined.WorkOutline
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
+import com.moviles.jobmatch.data.repository.ApiResult
+import com.moviles.jobmatch.data.repository.AppContainer
+import com.moviles.jobmatch.data.repository.StudentRepository
+import com.moviles.jobmatch.ui.components.SkillChip
+import com.moviles.jobmatch.ui.theme.DarkBlue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+// --- ViewModel ---
+
+private data class UiState(
+    val isLoading: Boolean = false,
+    val student: StudentProfileResponse? = null,
+    val errorMessage: String? = null
+)
+
+private class StudentPublicProfileViewModel(
+    private val studentId: String,
+    private val repository: StudentRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(UiState(isLoading = true))
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = UiState(isLoading = true)
+            when (val result = repository.getStudentProfile(studentId)) {
+                is ApiResult.Success -> _uiState.value = UiState(student = result.data)
+                is ApiResult.Error -> _uiState.value = UiState(errorMessage = result.message)
+            }
+        }
+    }
+}
+
+private class Factory(
+    private val studentId: String,
+    private val repository: StudentRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return StudentPublicProfileViewModel(studentId, repository) as T
+    }
+}
+
+// --- Screen ---
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StudentPublicProfileScreen(
+    studentId: String,
+    onBackPressed: () -> Unit = {}
+) {
+    val viewModel: StudentPublicProfileViewModel = viewModel(
+        key = studentId,
+        factory = Factory(studentId, AppContainer.studentRepository)
+    )
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Perfil del Estudiante", fontWeight = FontWeight.SemiBold) },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Volver")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
+            )
+        },
+        containerColor = Color(0xFFF5F7FA)
+    ) { padding ->
+        when {
+            uiState.isLoading -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator(color = DarkBlue) }
+
+            uiState.errorMessage != null -> Box(
+                Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.padding(24.dp)
+                ) {
+                    Text(uiState.errorMessage!!, color = Color.Gray)
+                    Button(
+                        onClick = viewModel::load,
+                        colors = ButtonDefaults.buttonColors(containerColor = DarkBlue)
+                    ) { Text("Reintentar") }
+                }
+            }
+
+            uiState.student != null -> ProfileContent(
+                student = uiState.student!!,
+                modifier = Modifier.padding(padding)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileContent(student: StudentProfileResponse, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Avatar + nombre + rating
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(2.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp).fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(72.dp)
+                        .clip(CircleShape)
+                        .background(DarkBlue),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = student.user.fullName.take(2).uppercase(),
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 26.sp
+                    )
+                }
+                Text(
+                    student.user.fullName,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp,
+                    color = Color(0xFF1A1A2E)
+                )
+                if (student.averageRating > 0f) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Icon(
+                            Icons.Outlined.Star, null,
+                            tint = Color(0xFFFFC107),
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Text(
+                            "%.1f".format(student.averageRating),
+                            fontSize = 14.sp,
+                            color = Color(0xFF555555),
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+                }
+            }
+        }
+
+        // Info académica
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(2.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                Text(
+                    "Información Académica",
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 13.sp,
+                    color = Color(0xFF8A9BB0)
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Icon(Icons.Outlined.School, null, tint = DarkBlue, modifier = Modifier.size(20.dp))
+                    Column {
+                        Text(student.university, fontWeight = FontWeight.Medium, fontSize = 14.sp)
+                        Text(student.career, fontSize = 12.sp, color = Color(0xFF8A9BB0))
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Icon(Icons.Outlined.WorkOutline, null, tint = DarkBlue, modifier = Modifier.size(20.dp))
+                    Text(student.user.email, fontSize = 13.sp, color = Color(0xFF555555))
+                }
+            }
+        }
+
+        // Skills
+        if (student.skills.isNotEmpty()) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White),
+                elevation = CardDefaults.cardElevation(2.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        "Habilidades",
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 13.sp,
+                        color = Color(0xFF8A9BB0)
+                    )
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        student.skills.forEach { skill ->
+                            SkillChip(text = skill)
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentPublicProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentPublicProfileScreen.kt
@@ -7,10 +7,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.School
 import androidx.compose.material.icons.outlined.Star
-import androidx.compose.material.icons.outlined.WorkOutline
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -20,61 +20,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
-import com.moviles.jobmatch.data.repository.ApiResult
 import com.moviles.jobmatch.data.repository.AppContainer
-import com.moviles.jobmatch.data.repository.StudentRepository
 import com.moviles.jobmatch.ui.components.SkillChip
 import com.moviles.jobmatch.ui.theme.DarkBlue
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
-
-// --- ViewModel ---
-
-private data class UiState(
-    val isLoading: Boolean = false,
-    val student: StudentProfileResponse? = null,
-    val errorMessage: String? = null
-)
-
-private class StudentPublicProfileViewModel(
-    private val studentId: String,
-    private val repository: StudentRepository
-) : ViewModel() {
-    private val _uiState = MutableStateFlow(UiState(isLoading = true))
-    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
-
-    init { load() }
-
-    fun load() {
-        viewModelScope.launch {
-            _uiState.value = UiState(isLoading = true)
-            when (val result = repository.getStudentProfile(studentId)) {
-                is ApiResult.Success -> _uiState.value = UiState(student = result.data)
-                is ApiResult.Error -> _uiState.value = UiState(errorMessage = result.message)
-            }
-        }
-    }
-}
-
-private class Factory(
-    private val studentId: String,
-    private val repository: StudentRepository
-) : ViewModelProvider.Factory {
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        @Suppress("UNCHECKED_CAST")
-        return StudentPublicProfileViewModel(studentId, repository) as T
-    }
-}
-
-// --- Screen ---
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -84,7 +34,7 @@ fun StudentPublicProfileScreen(
 ) {
     val viewModel: StudentPublicProfileViewModel = viewModel(
         key = studentId,
-        factory = Factory(studentId, AppContainer.studentRepository)
+        factory = StudentPublicProfileViewModel.Factory(studentId, AppContainer.studentRepository)
     )
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -94,7 +44,7 @@ fun StudentPublicProfileScreen(
                 title = { Text("Perfil del Estudiante", fontWeight = FontWeight.SemiBold) },
                 navigationIcon = {
                     IconButton(onClick = onBackPressed) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Volver")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
@@ -134,7 +84,10 @@ fun StudentPublicProfileScreen(
 }
 
 @Composable
-private fun ProfileContent(student: StudentProfileResponse, modifier: Modifier = Modifier) {
+private fun ProfileContent(
+    student: com.moviles.jobmatch.data.remote.model.StudentProfileResponse,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -142,7 +95,7 @@ private fun ProfileContent(student: StudentProfileResponse, modifier: Modifier =
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        // Avatar + nombre + rating
+        // Avatar, name, and rating
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(20.dp),
@@ -195,7 +148,7 @@ private fun ProfileContent(student: StudentProfileResponse, modifier: Modifier =
             }
         }
 
-        // Info académica
+        // Academic info
         Card(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(16.dp),
@@ -226,7 +179,7 @@ private fun ProfileContent(student: StudentProfileResponse, modifier: Modifier =
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
-                    Icon(Icons.Outlined.WorkOutline, null, tint = DarkBlue, modifier = Modifier.size(20.dp))
+                    Icon(Icons.Outlined.Email, null, tint = DarkBlue, modifier = Modifier.size(20.dp))
                     Text(student.user.email, fontSize = 13.sp, color = Color(0xFF555555))
                 }
             }

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentPublicProfileViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentPublicProfileViewModel.kt
@@ -1,0 +1,49 @@
+package com.moviles.jobmatch.ui.screens.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
+import com.moviles.jobmatch.data.repository.ApiResult
+import com.moviles.jobmatch.data.repository.StudentRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class StudentPublicProfileUiState(
+    val isLoading: Boolean = false,
+    val student: StudentProfileResponse? = null,
+    val errorMessage: String? = null
+)
+
+class StudentPublicProfileViewModel(
+    private val studentId: String,
+    private val repository: StudentRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(StudentPublicProfileUiState(isLoading = true))
+    val uiState: StateFlow<StudentPublicProfileUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = StudentPublicProfileUiState(isLoading = true)
+            when (val result = repository.getStudentProfile(studentId)) {
+                is ApiResult.Success -> _uiState.value = StudentPublicProfileUiState(student = result.data)
+                is ApiResult.Error   -> _uiState.value = StudentPublicProfileUiState(errorMessage = result.message)
+            }
+        }
+    }
+
+    class Factory(
+        private val studentId: String,
+        private val repository: StudentRepository
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return StudentPublicProfileViewModel(studentId, repository) as T
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/utils/JobFormatters.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/utils/JobFormatters.kt
@@ -23,6 +23,22 @@ fun formatJobDate(dateStr: String): String {
     }
 }
 
+fun formatApplicationDate(isoDate: String): String {
+    return try {
+        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+        val date = sdf.parse(isoDate) ?: return isoDate
+        SimpleDateFormat("dd 'de' MMM yyyy", Locale("es")).format(date)
+    } catch (e: Exception) {
+        try {
+            val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val date = sdf.parse(isoDate) ?: return isoDate
+            SimpleDateFormat("dd 'de' MMM yyyy", Locale("es")).format(date)
+        } catch (e2: Exception) {
+            isoDate
+        }
+    }
+}
+
 fun formatPaymentType(type: String): String = when (type.lowercase()) {
     "fixed", "fijo" -> "Fijo"
     "hourly", "hora", "por hora" -> "Por hora"


### PR DESCRIPTION
# Extraction Request

## Description

Implements issue #32: Company users can now view all the details of a specific request (status, job ID, student ID, and creation date) and access the student's public profile with their skills.

---

## Related Issue

Close #32

---

## Changes Included

### Backend Changes

* [ ] Added new endpoints
* [ ] Added/updated DTOs
* [ ] Added/updated services
* [ ] Added/updated repositories
* [ ] Added/updated database migrations
* [ ] Added validations
* [ ] Added exception handling
* [ ] Other:

### Frontend/Mobile Changes

* [ ] Added new screens
* [ ] Added ViewModels
* [ ] Added navigation
* [ ] Added API integration
* [ ] Added load/error states
* [ ] Added validation
* [ ] Updated UI components
* [ ] Other:

---

## Architecture

User Interface (Application Screen) → ApplicationDetailScreen → StudentPublicProfileScreen → ViewModel → StudentRepository → Retrofit → Backend

---

## API/Database Changes

Uses existing endpoints:
- GET /jobs/{jobId}/applications — already implemented, returns createdAt, idStudent, status, idJob
- GET /students/{studentId} — full profile + skills

---

## Tests Performed

* [ ] Functionality tested manually
* [ ] Navigation tested
* [ ] Error handling tested
* [ ] Validation tested
* [ ] Backend integration tested
* [ ] No bugs detected

### Test Details

Navigation From ApplicationsScreen → ApplicationDetailScreen, all fields are displayed correctly. The "View Full Profile" button navigates to the StudentPublicProfileScreen with name, university, major, and skills. The status banner changes color depending on whether the application is accepted, rejected, or pending.

---

## Evidence

### Screenshots/Videos

<img width="351" height="728" alt="Screenshot 2026-06-11 002257" src="https://github.com/user-attachments/assets/db8b54ce-9ccb-44c3-b6cb-ffa69a58356c" />

##Notes

Requires PR companion on the backend: GET /students/{studentId} used to return 403 for enterprise users (self-only restriction removed). The student side (tracking their own application) remains blocked until the Apply to Job feature is available.
