### PR TITLE
Feature/apply for a job

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -13,6 +13,8 @@ import com.moviles.jobmatch.data.remote.model.RegisterStudentRequest
 import com.moviles.jobmatch.data.remote.model.CreateJobRequest
 import com.moviles.jobmatch.data.remote.model.CreateJobResponse
 import com.moviles.jobmatch.data.remote.model.ApplicationResponse
+import com.moviles.jobmatch.data.remote.model.CreateApplicationRequest
+import com.moviles.jobmatch.data.remote.model.CreateApplicationResponse
 import com.moviles.jobmatch.data.remote.model.UpdateApplicationRequest
 import com.moviles.jobmatch.data.remote.model.UpdateApplicationResponse
 import com.moviles.jobmatch.data.remote.model.UpdateJobRequest
@@ -54,6 +56,9 @@ interface ApiService {
         @Path("jobId") jobId: Int,
         @Body request: UpdateJobRequest
     ): Response<JobDetailResponse>
+
+    @POST("applications")
+    suspend fun applyToJob(@Body request: CreateApplicationRequest): Response<CreateApplicationResponse>
 
     @GET("jobs/{jobId}/applications")
     suspend fun getApplicationsByJob(@Path("jobId") jobId: Int): Response<List<ApplicationResponse>>

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/ApplicationModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/ApplicationModels.kt
@@ -22,3 +22,7 @@ data class UpdateApplicationResponse(
     val status: String,
     val message: String
 )
+
+data class CreateApplicationRequest(val idJob: Int)
+
+data class CreateApplicationResponse(val message: String, val status: String)

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/ApplicationRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/ApplicationRepository.kt
@@ -17,17 +17,17 @@ class ApplicationRepository(private val apiService: ApiService) {
                 ApiResult.Success(response.body()!!)
             } else {
                 val message = when (response.code()) {
-                    403 -> "Only students can apply for job offers"
-                    404 -> "Job offer not found"
-                    409 -> "You have already applied to this job"
-                    else -> "Failed to submit application (${response.code()})"
+                    403 -> "Solo los estudiantes pueden aplicar a ofertas de empleo"
+                    404 -> "Oferta de empleo no encontrada"
+                    409 -> "Ya has aplicado a esta oferta de empleo"
+                    else -> "Fallo al subir aplicación (${response.code()})"
                 }
                 ApiResult.Error(message, response.code())
             }
         } catch (e: IOException) {
-            ApiResult.Error("Could not connect to server")
+            ApiResult.Error("No se pudo conectar al servidor")
         } catch (e: Exception) {
-            ApiResult.Error(e.message ?: "Unexpected error")
+            ApiResult.Error(e.message ?: "Error inesperado")
         }
     }
 

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/ApplicationRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/ApplicationRepository.kt
@@ -2,11 +2,34 @@ package com.moviles.jobmatch.data.repository
 
 import com.moviles.jobmatch.data.remote.ApiService
 import com.moviles.jobmatch.data.remote.model.ApplicationResponse
+import com.moviles.jobmatch.data.remote.model.CreateApplicationRequest
+import com.moviles.jobmatch.data.remote.model.CreateApplicationResponse
 import com.moviles.jobmatch.data.remote.model.UpdateApplicationRequest
 import com.moviles.jobmatch.data.remote.model.UpdateApplicationResponse
 import java.io.IOException
 
 class ApplicationRepository(private val apiService: ApiService) {
+
+    suspend fun applyToJob(jobId: Int): ApiResult<CreateApplicationResponse> {
+        return try {
+            val response = apiService.applyToJob(CreateApplicationRequest(jobId))
+            if (response.isSuccessful && response.body() != null) {
+                ApiResult.Success(response.body()!!)
+            } else {
+                val message = when (response.code()) {
+                    403 -> "Only students can apply for job offers"
+                    404 -> "Job offer not found"
+                    409 -> "You have already applied to this job"
+                    else -> "Failed to submit application (${response.code()})"
+                }
+                ApiResult.Error(message, response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("Could not connect to server")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Unexpected error")
+        }
+    }
 
     suspend fun getApplicationsByJob(jobId: Int): ApiResult<List<ApplicationResponse>> {
         return try {

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/job/JobDetailScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/job/JobDetailScreen.kt
@@ -47,12 +47,29 @@ fun JobDetailScreen(
     viewModel: JobDetailViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val applyState by viewModel.applyState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(jobId, refreshKey) {
         viewModel.loadJobDetail(jobId)
     }
 
+    LaunchedEffect(applyState) {
+        when (val state = applyState) {
+            is ApplyState.Success -> {
+                snackbarHostState.showSnackbar("Application submitted successfully!")
+                viewModel.resetApplyState()
+            }
+            is ApplyState.Error -> {
+                snackbarHostState.showSnackbar(state.message)
+                viewModel.resetApplyState()
+            }
+            else -> {}
+        }
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
@@ -90,7 +107,10 @@ fun JobDetailScreen(
                         onEdit = { onEditJob(job.idJob) }
                     )
                 } else {
-                    JobDetailBottomBar()
+                    JobDetailBottomBar(
+                        isApplying = applyState is ApplyState.Loading,
+                        onApply = { viewModel.applyToJob(job.idJob) }
+                    )
                 }
             }
         },
@@ -805,7 +825,10 @@ private fun TrustCard() {
 }
 
 @Composable
-private fun JobDetailBottomBar() {
+private fun JobDetailBottomBar(
+    isApplying: Boolean = false,
+    onApply: () -> Unit = {}
+) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shadowElevation = 12.dp,
@@ -833,24 +856,33 @@ private fun JobDetailBottomBar() {
             }
 
             Button(
-                onClick = {},
+                onClick = onApply,
+                enabled = !isApplying,
                 modifier = Modifier
                     .weight(1f)
                     .height(50.dp),
                 shape = RoundedCornerShape(14.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = DarkBlue)
             ) {
-                Text(
-                    text = "Postularse Ahora",
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 15.sp
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Icon(
-                    imageVector = Icons.Default.ArrowForward,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp)
-                )
+                if (isApplying) {
+                    CircularProgressIndicator(
+                        color = Color.White,
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text(
+                        text = "Postularse Ahora",
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 15.sp
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Icon(
+                        imageVector = Icons.Default.ArrowForward,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/job/JobDetailViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/job/JobDetailViewModel.kt
@@ -16,11 +16,22 @@ sealed class JobDetailUiState {
     data class Error(val message: String) : JobDetailUiState()
 }
 
+sealed class ApplyState {
+    data object Idle : ApplyState()
+    data object Loading : ApplyState()
+    data object Success : ApplyState()
+    data class Error(val message: String) : ApplyState()
+}
+
 class JobDetailViewModel : ViewModel() {
     private val repository = AppContainer.jobRepository
+    private val applicationRepository = AppContainer.applicationRepository
 
     private val _uiState = MutableStateFlow<JobDetailUiState>(JobDetailUiState.Loading)
     val uiState: StateFlow<JobDetailUiState> = _uiState.asStateFlow()
+
+    private val _applyState = MutableStateFlow<ApplyState>(ApplyState.Idle)
+    val applyState: StateFlow<ApplyState> = _applyState.asStateFlow()
 
     fun loadJobDetail(jobId: Int) {
         viewModelScope.launch {
@@ -30,5 +41,20 @@ class JobDetailViewModel : ViewModel() {
                 is ApiResult.Error -> _uiState.value = JobDetailUiState.Error(result.message)
             }
         }
+    }
+
+    fun applyToJob(jobId: Int) {
+        if (_applyState.value is ApplyState.Loading) return
+        viewModelScope.launch {
+            _applyState.value = ApplyState.Loading
+            when (val result = applicationRepository.applyToJob(jobId)) {
+                is ApiResult.Success -> _applyState.value = ApplyState.Success
+                is ApiResult.Error -> _applyState.value = ApplyState.Error(result.message)
+            }
+        }
+    }
+
+    fun resetApplyState() {
+        _applyState.value = ApplyState.Idle
     }
 }


### PR DESCRIPTION
# Pull Request

 ## Description

  Implements the apply-to-job flow for students. This PR wires up the existing "Postularse Ahora" button in JobDetailScreen so that tapping it sends POST
  /applications with the job ID. The button shows a loading spinner while the request is in flight and is disabled to prevent double-submission. A Snackbar
  displays the result — success confirmation or the appropriate error message (already applied, not a student, job not found, network failure).

  ---
 ## Related Issue

  Closes #14  (Apply to job from job detail screen)

  ---
  ## Changes Included

  ### Frontend / Mobile Changes

  - [ ] Added new screen(s)
  - [ ] Added ViewModel(s)
  - [ ] Added navigation
  - [x] Added API integration
  - [x] Added loading/error states
  - [ ] Added validation
  - [x] Updated UI components
  - [x] Other: Added CreateApplicationRequest / CreateApplicationResponse models and ApplyState sealed class

  ---
  ## Architecture

  JobDetailScreen → JobDetailViewModel → ApplicationRepository → Retrofit → POST /applications

  JobDetailViewModel owns the ApplyState flow (Idle → Loading → Success / Error) and exposes applyToJob(jobId) and resetApplyState(). JobDetailScreen collects
  the state reactively, passes isApplying and onApply down to JobDetailBottomBar, and runs a LaunchedEffect to show a Snackbar and reset state after each
  result. ApplicationRepository handles the full HTTP contract including all documented error codes.

  ---
  ## API / Database Changes

  ### Endpoint used

  POST /applications

  Requires JWT (Authorization: Bearer {token}). The student ID is derived server-side from the token — only idJob is sent in the body.

  ### Request Body

  { "idJob": 6 }

  ### Responses handled

  - 201 Created — shows "Application submitted successfully!" Snackbar
  - 403 Forbidden — "Solo los estudiantes pueden aplicar a ofertas de empleo"
  - 404 Not Found — "Oferta de empleo no encontrada"
  - 409 Conflict — "Ya has aplicado a esta oferta de empleo"
  - Network error (IOException) — "No se pudo conectar al servidor"

  ### Database

  No changes. Uses the existing POST /applications endpoint already implemented in the backend.

  ---
  ## Testing Performed

  - [x] Feature tested manually
  - [ ] Navigation tested
  - [x] Error handling tested
  - [ ] Validation tested
  - [x] Backend integration tested
  - [x] No crashes detected

  ### Test Details

  The apply button is only visible to non-company users (AuthSession.isCompany guard was already in place). Double-tap is prevented:
  JobDetailViewModel.applyToJob returns immediately if ApplyState.Loading is already active. All documented HTTP error codes return user-readable messages via
  Snackbar. The button re-enables after the response is processed.

  ---
  ## Evidence

<img width="720" height="1604" alt="WhatsApp Image 2026-06-17 at 8 32 43 PM" src="https://github.com/user-attachments/assets/d6b1bff7-dfaa-45c4-a36c-db38cced02a2" />


  ---
  ## Notes

  This PR only implements submitting a new application. Cancelling an application, viewing application status from the student side, and persisting the "already
  applied" state across navigation sessions are out of scope for this change.