### PR TITLE
feat: Account deletion

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -17,9 +17,12 @@ import com.moviles.jobmatch.data.remote.model.UpdateApplicationRequest
 import com.moviles.jobmatch.data.remote.model.UpdateApplicationResponse
 import com.moviles.jobmatch.data.remote.model.UpdateJobRequest
 import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
+import com.moviles.jobmatch.data.remote.model.DeleteUserRequest
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -68,4 +71,10 @@ interface ApiService {
     suspend fun getStudentProfile(
         @Path("studentId") studentId: String
     ): Response<StudentProfileResponse>
+
+    @HTTP(method = "DELETE", path = "users/{userId}", hasBody = true)
+    suspend fun deleteUser(
+        @Path("userId") userId: String,
+        @Body request: DeleteUserRequest
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/AuthModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/AuthModels.kt
@@ -38,3 +38,7 @@ data class RegisterResponse(
     val userId: String,
     val message: String
 )
+
+data class DeleteUserRequest(
+    val password: String
+)

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/AppContainer.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/AppContainer.kt
@@ -22,4 +22,8 @@ object AppContainer {
     val studentRepository: StudentRepository by lazy {
         StudentRepository(RetrofitClient.apiService)
     }
+
+    val userRepository: UserRepository by lazy {
+        UserRepository(RetrofitClient.apiService)
+    }
 }

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/UserRepository.kt
@@ -1,0 +1,26 @@
+package com.moviles.jobmatch.data.repository
+
+import com.moviles.jobmatch.data.remote.ApiService
+import com.moviles.jobmatch.data.remote.model.DeleteUserRequest
+import java.io.IOException
+
+class UserRepository(private val apiService: ApiService) {
+
+    suspend fun deleteAccount(userId: String, password: String): ApiResult<Unit> {
+        return try {
+            val response = apiService.deleteUser(userId, DeleteUserRequest(password))
+            when {
+                response.isSuccessful -> ApiResult.Success(Unit)
+                response.code() == 401 -> ApiResult.Error("Credenciales incorrectas", 401)
+                response.code() == 403 -> ApiResult.Error("No tienes permiso para realizar esta acción", 403)
+                response.code() == 404 -> ApiResult.Error("Usuario no encontrado", 404)
+                response.code() == 400 -> ApiResult.Error("Contraseña incorrecta", 400)
+                else -> ApiResult.Error("Error del servidor (${response.code()})", response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado")
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
@@ -172,11 +172,23 @@ fun AppNavHost(modifier: Modifier = Modifier) {
             }
 
             composable(route = AppDestinations.PROFILE) {
-                StudentProfileScreen()
+                StudentProfileScreen(
+                    onAccountDeleted = {
+                        navController.navigate(AppDestinations.LOGIN) {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    }
+                )
             }
 
             composable(route = AppDestinations.STUDENT_PROFILE) {
-                StudentProfileScreen()
+                StudentProfileScreen(
+                    onAccountDeleted = {
+                        navController.navigate(AppDestinations.LOGIN) {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    }
+                )
             }
 
             composable(
@@ -198,7 +210,12 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                 val id = backStackEntry.arguments?.getString("companyId").orEmpty()
                 CompanyProfileScreen(
                     companyId = id,
-                    onBackPressed = { navController.popBackStack() }
+                    onBackPressed = { navController.popBackStack() },
+                    onAccountDeleted = {
+                        navController.navigate(AppDestinations.LOGIN) {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    }
                 )
             }
 

--- a/app/src/main/java/com/moviles/jobmatch/ui/components/DeleteAccountDialog.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/components/DeleteAccountDialog.kt
@@ -1,0 +1,109 @@
+package com.moviles.jobmatch.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DeleteAccountDialog(
+    isLoading: Boolean,
+    errorMessage: String?,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        title = { Text("Eliminar cuenta", fontWeight = FontWeight.Bold) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "Esta acción es permanente y no se puede deshacer. " +
+                    "Ingresa tu contraseña para confirmar.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0xFF5A6A7A)
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text("Contraseña") },
+                    singleLine = true,
+                    visualTransformation = if (passwordVisible)
+                        VisualTransformation.None
+                    else
+                        PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible)
+                                    Icons.Default.VisibilityOff
+                                else
+                                    Icons.Default.Visibility,
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                if (errorMessage != null) {
+                    Text(
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.CenterHorizontally).size(24.dp),
+                        color = Color(0xFFE53935)
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(password) },
+                enabled = password.isNotBlank() && !isLoading,
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFE53935))
+            ) {
+                Text("Eliminar")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isLoading) {
+                Text("Cancelar")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
@@ -1,9 +1,11 @@
 package com.moviles.jobmatch.ui.screens.company
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -11,11 +13,19 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.moviles.jobmatch.data.AuthSession
 import com.moviles.jobmatch.data.Company
+import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.*
+import com.moviles.jobmatch.ui.screens.profile.DeleteAccountViewModel
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -24,12 +34,25 @@ fun CompanyProfileScreen(
     companyId: String,
     onBackPressed: () -> Unit = {},
     onSettingsPressed: () -> Unit = {},
+    onAccountDeleted: () -> Unit = {},
     viewModel: CompanyProfileViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
+    val deleteViewModel: DeleteAccountViewModel = viewModel(
+        factory = DeleteAccountViewModel.Factory(AppContainer.userRepository)
+    )
+    val deleteUiState by deleteViewModel.uiState.collectAsStateWithLifecycle()
+
+    val isOwnProfile = companyId == AuthSession.currentUser?.userId
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
     LaunchedEffect(companyId) {
         viewModel.loadCompanyProfile(companyId)
+    }
+
+    LaunchedEffect(deleteUiState.isDeleted) {
+        if (deleteUiState.isDeleted) onAccountDeleted()
     }
 
     Scaffold(
@@ -55,6 +78,8 @@ fun CompanyProfileScreen(
                 val company = (uiState as CompanyUiState.Success).company
                 CompanyProfileContent(
                     company = company,
+                    isOwnProfile = isOwnProfile,
+                    onDeleteClick = { showDeleteDialog = true },
                     modifier = Modifier.padding(paddingValues)
                 )
             }
@@ -78,12 +103,28 @@ fun CompanyProfileScreen(
             }
         }
     }
+
+    if (showDeleteDialog) {
+        CompanyDeleteAccountDialog(
+            isLoading = deleteUiState.isLoading,
+            errorMessage = deleteUiState.errorMessage,
+            onConfirm = { password ->
+                deleteViewModel.deleteAccount(password)
+            },
+            onDismiss = {
+                showDeleteDialog = false
+                deleteViewModel.clearError()
+            }
+        )
+    }
 }
 
 @Composable
 fun CompanyProfileContent(
     company: Company,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isOwnProfile: Boolean = false,
+    onDeleteClick: () -> Unit = {}
 ) {
     Column(
         modifier = modifier
@@ -136,7 +177,102 @@ fun CompanyProfileContent(
             )
         }
 
+        if (isOwnProfile) {
+            OutlinedButton(
+                onClick = onDeleteClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .height(48.dp),
+                shape = RoundedCornerShape(12.dp),
+                border = BorderStroke(1.dp, Color(0xFFE53935)),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = Color(0xFFE53935))
+            ) {
+                Text(
+                    text = "Eliminar cuenta",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+
         Spacer(modifier = Modifier.height(32.dp))
     }
+}
+
+@Composable
+private fun CompanyDeleteAccountDialog(
+    isLoading: Boolean,
+    errorMessage: String?,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        title = { Text("Eliminar cuenta", fontWeight = FontWeight.Bold) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "Esta acción es permanente y no se puede deshacer. " +
+                    "Ingresa tu contraseña para confirmar.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0xFF5A6A7A)
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text("Contraseña") },
+                    singleLine = true,
+                    visualTransformation = if (passwordVisible)
+                        VisualTransformation.None
+                    else
+                        PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible)
+                                    Icons.Default.VisibilityOff
+                                else
+                                    Icons.Default.Visibility,
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                if (errorMessage != null) {
+                    Text(
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.CenterHorizontally).size(24.dp),
+                        color = Color(0xFFE53935)
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(password) },
+                enabled = password.isNotBlank() && !isLoading,
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFE53935))
+            ) {
+                Text("Eliminar")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isLoading) {
+                Text("Cancelar")
+            }
+        }
+    )
 }
 

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -15,9 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -105,7 +101,7 @@ fun CompanyProfileScreen(
     }
 
     if (showDeleteDialog) {
-        CompanyDeleteAccountDialog(
+        DeleteAccountDialog(
             isLoading = deleteUiState.isLoading,
             errorMessage = deleteUiState.errorMessage,
             onConfirm = { password ->
@@ -200,79 +196,4 @@ fun CompanyProfileContent(
     }
 }
 
-@Composable
-private fun CompanyDeleteAccountDialog(
-    isLoading: Boolean,
-    errorMessage: String?,
-    onConfirm: (String) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var password by remember { mutableStateOf("") }
-    var passwordVisible by remember { mutableStateOf(false) }
-
-    AlertDialog(
-        onDismissRequest = { if (!isLoading) onDismiss() },
-        title = { Text("Eliminar cuenta", fontWeight = FontWeight.Bold) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(
-                    "Esta acción es permanente y no se puede deshacer. " +
-                    "Ingresa tu contraseña para confirmar.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color(0xFF5A6A7A)
-                )
-                OutlinedTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    label = { Text("Contraseña") },
-                    singleLine = true,
-                    visualTransformation = if (passwordVisible)
-                        VisualTransformation.None
-                    else
-                        PasswordVisualTransformation(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    trailingIcon = {
-                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
-                            Icon(
-                                imageVector = if (passwordVisible)
-                                    Icons.Default.VisibilityOff
-                                else
-                                    Icons.Default.Visibility,
-                                contentDescription = null
-                            )
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                if (errorMessage != null) {
-                    Text(
-                        text = errorMessage,
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-                if (isLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.CenterHorizontally).size(24.dp),
-                        color = Color(0xFFE53935)
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            Button(
-                onClick = { onConfirm(password) },
-                enabled = password.isNotBlank() && !isLoading,
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFE53935))
-            ) {
-                Text("Eliminar")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss, enabled = !isLoading) {
-                Text("Cancelar")
-            }
-        }
-    )
-}
 

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/DeleteAccountViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/DeleteAccountViewModel.kt
@@ -1,0 +1,53 @@
+package com.moviles.jobmatch.ui.screens.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.moviles.jobmatch.data.AuthSession
+import com.moviles.jobmatch.data.repository.ApiResult
+import com.moviles.jobmatch.data.repository.UserRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class DeleteAccountUiState(
+    val isLoading: Boolean = false,
+    val isDeleted: Boolean = false,
+    val errorMessage: String? = null
+)
+
+class DeleteAccountViewModel(
+    private val userRepository: UserRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DeleteAccountUiState())
+    val uiState: StateFlow<DeleteAccountUiState> = _uiState.asStateFlow()
+
+    fun deleteAccount(password: String) {
+        val userId = AuthSession.currentUser?.userId ?: return
+        viewModelScope.launch {
+            _uiState.value = DeleteAccountUiState(isLoading = true)
+            when (val result = userRepository.deleteAccount(userId, password)) {
+                is ApiResult.Success -> {
+                    AuthSession.clear()
+                    _uiState.value = DeleteAccountUiState(isDeleted = true)
+                }
+                is ApiResult.Error -> {
+                    _uiState.value = DeleteAccountUiState(errorMessage = result.message)
+                }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(errorMessage = null)
+    }
+
+    class Factory(private val userRepository: UserRepository) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return DeleteAccountViewModel(userRepository) as T
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -24,22 +23,15 @@ import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.TrendingUp
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -50,15 +42,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.remote.model.AvailabilityResponse
 import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.DayAvailabilitySelector
+import com.moviles.jobmatch.ui.components.DeleteAccountDialog
 import com.moviles.jobmatch.ui.components.InfoRow
 import com.moviles.jobmatch.ui.components.JobMatchTopBar
 import com.moviles.jobmatch.ui.components.SectionHeader
@@ -350,82 +340,6 @@ fun StudentProfileScreen(
             }
         )
     }
-}
-
-@Composable
-private fun DeleteAccountDialog(
-    isLoading: Boolean,
-    errorMessage: String?,
-    onConfirm: (String) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var password by remember { mutableStateOf("") }
-    var passwordVisible by remember { mutableStateOf(false) }
-
-    AlertDialog(
-        onDismissRequest = { if (!isLoading) onDismiss() },
-        title = { Text("Eliminar cuenta", fontWeight = FontWeight.Bold) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(
-                    "Esta acción es permanente y no se puede deshacer. " +
-                    "Ingresa tu contraseña para confirmar.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color(0xFF5A6A7A)
-                )
-                OutlinedTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    label = { Text("Contraseña") },
-                    singleLine = true,
-                    visualTransformation = if (passwordVisible)
-                        VisualTransformation.None
-                    else
-                        PasswordVisualTransformation(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    trailingIcon = {
-                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
-                            Icon(
-                                imageVector = if (passwordVisible)
-                                    Icons.Default.VisibilityOff
-                                else
-                                    Icons.Default.Visibility,
-                                contentDescription = null
-                            )
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                if (errorMessage != null) {
-                    Text(
-                        text = errorMessage,
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-                if (isLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.CenterHorizontally).size(24.dp),
-                        color = Color(0xFFE53935)
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            Button(
-                onClick = { onConfirm(password) },
-                enabled = password.isNotBlank() && !isLoading,
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFE53935))
-            ) {
-                Text("Eliminar")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss, enabled = !isLoading) {
-                Text("Cancelar")
-            }
-        }
-    )
 }
 
 private fun AvailabilityResponse?.toSelectedDays(): List<Boolean> {

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -23,21 +24,35 @@ import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -54,12 +69,24 @@ import com.moviles.jobmatch.ui.theme.DarkBlue
 
 @Composable
 fun StudentProfileScreen(
-    onSettingsClick: () -> Unit = {}
+    onSettingsClick: () -> Unit = {},
+    onAccountDeleted: () -> Unit = {}
 ) {
     val viewModel: StudentProfileViewModel = viewModel(
         factory = StudentProfileViewModelFactory(AppContainer.studentRepository)
     )
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val deleteViewModel: DeleteAccountViewModel = viewModel(
+        factory = DeleteAccountViewModel.Factory(AppContainer.userRepository)
+    )
+    val deleteUiState by deleteViewModel.uiState.collectAsStateWithLifecycle()
+
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(deleteUiState.isDeleted) {
+        if (deleteUiState.isDeleted) onAccountDeleted()
+    }
 
     Scaffold(
         topBar = {
@@ -284,6 +311,24 @@ fun StudentProfileScreen(
                                 fontWeight = FontWeight.Medium
                             )
                         }
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        OutlinedButton(
+                            onClick = { showDeleteDialog = true },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(48.dp),
+                            shape = RoundedCornerShape(12.dp),
+                            border = BorderStroke(1.dp, Color(0xFFE53935)),
+                            colors = ButtonDefaults.outlinedButtonColors(contentColor = Color(0xFFE53935))
+                        ) {
+                            Text(
+                                text = "Eliminar cuenta",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
                     }
 
                     Spacer(modifier = Modifier.height(24.dp))
@@ -291,6 +336,96 @@ fun StudentProfileScreen(
             }
         }
     }
+
+    if (showDeleteDialog) {
+        DeleteAccountDialog(
+            isLoading = deleteUiState.isLoading,
+            errorMessage = deleteUiState.errorMessage,
+            onConfirm = { password ->
+                deleteViewModel.deleteAccount(password)
+            },
+            onDismiss = {
+                showDeleteDialog = false
+                deleteViewModel.clearError()
+            }
+        )
+    }
+}
+
+@Composable
+private fun DeleteAccountDialog(
+    isLoading: Boolean,
+    errorMessage: String?,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        title = { Text("Eliminar cuenta", fontWeight = FontWeight.Bold) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    "Esta acción es permanente y no se puede deshacer. " +
+                    "Ingresa tu contraseña para confirmar.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0xFF5A6A7A)
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text("Contraseña") },
+                    singleLine = true,
+                    visualTransformation = if (passwordVisible)
+                        VisualTransformation.None
+                    else
+                        PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible)
+                                    Icons.Default.VisibilityOff
+                                else
+                                    Icons.Default.Visibility,
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                if (errorMessage != null) {
+                    Text(
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.align(Alignment.CenterHorizontally).size(24.dp),
+                        color = Color(0xFFE53935)
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(password) },
+                enabled = password.isNotBlank() && !isLoading,
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFE53935))
+            ) {
+                Text("Eliminar")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isLoading) {
+                Text("Cancelar")
+            }
+        }
+    )
 }
 
 private fun AvailabilityResponse?.toSelectedDays(): List<Boolean> {


### PR DESCRIPTION
# Pull Request

## Description

Implements the account deletion feature for both student and company users. Users can permanently delete their account from their profile screen by confirming their password. After deletion the session is cleared and the user is redirected to the login screen.

---

## Related Issue

Closes #5 

---

## Changes Included

### Backend Changes

* [ ] Added new endpoint(s)
* [ ] Added/updated DTOs
* [ ] Added/updated services
* [ ] Added/updated repositories
* [ ] Added/updated database migrations
* [ ] Added validations
* [ ] Added exception handling
* [ ] Other:

### Frontend / Mobile Changes

* [x] Added new screen(s)
* [x] Added ViewModel(s)
* [x] Added navigation
* [x] Added API integration
* [x] Added loading/error states
* [x] Added validation
* [x] Updated UI components
* [ ] Other:

---

## Architecture

UI (StudentProfileScreen / CompanyProfileScreen)
  → DeleteAccountViewModel
    → UserRepository
      → ApiService (DELETE /users/{userId})
        → Backend: UsersController
          → UserService.SoftDeleteUserAsync
            → UserRepository (sets IsActive = false, DeletedAt = now)

---

## API / Database Changes

Endpoint: DELETE /users/{userId}

Authorization: Bearer token required

Request body:


{ "password": "string" }
Responses:

200 — Account successfully deleted
400 — Incorrect password or account already deleted
401 — Unauthenticated
403 — Authenticated user does not match userId
404 — User not found
Database: No schema changes. Sets IsActive = false and DeletedAt = DateTime.UtcNow on the user record (soft delete). Email and CompanyId are freed for re-registration by filtering all uniqueness checks with && u.IsActive.

---

## Testing Performed

* [x] Feature tested manually
* [x] Navigation tested
* [x] Error handling tested
* [x] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

Deleted a student account with correct password → redirected to login, session cleared ✓
Deleted a company account with correct password → redirected to login ✓
Attempted deletion with wrong password → error message shown in dialog ✓
Re-registered with the same email after deletion → registration succeeded ✓
Login with the deleted account → correctly rejected ✓
Viewed another company's profile → delete button does not appear ✓

---

## Evidence

### Screenshots / Videos

<img width="358" height="710" alt="Captura de pantalla 2026-06-17 213206" src="https://github.com/user-attachments/assets/deca076e-4d84-4400-8a56-4b8103566db7" />
<img width="307" height="424" alt="Captura de pantalla 2026-06-17 213215" src="https://github.com/user-attachments/assets/c43329ad-828b-4bbb-b844-15264c71cd33" />

---

## Notes

The delete button in CompanyProfileScreen only appears when companyId == AuthSession.currentUser?.userId, so other users viewing a company profile do not see the option.
Retrofit does not allow @Body with @DELETE by default; used @HTTP(method = "DELETE", hasBody = true) as workaround.
Soft delete was chosen to preserve referential integrity with contracts, applications and job history.