### PR TITLE
Feature/display contracts student profile

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -19,6 +19,8 @@ import com.moviles.jobmatch.data.remote.model.UpdateApplicationRequest
 import com.moviles.jobmatch.data.remote.model.UpdateApplicationResponse
 import com.moviles.jobmatch.data.remote.model.UpdateJobRequest
 import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
+import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
+import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.remote.model.DeleteUserRequest
 import retrofit2.Response
 import retrofit2.http.Body
@@ -76,6 +78,12 @@ interface ApiService {
     suspend fun getStudentProfile(
         @Path("studentId") studentId: String
     ): Response<StudentProfileResponse>
+
+    @GET("contracts/student")
+    suspend fun getStudentContracts(): Response<List<ContractListResponse>>
+
+    @GET("contracts/{contractId}")
+    suspend fun getContractById(@Path("contractId") contractId: Int): Response<ContractDetailResponse>
 
     @HTTP(method = "DELETE", path = "users/{userId}", hasBody = true)
     suspend fun deleteUser(

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/ContractModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/ContractModels.kt
@@ -31,12 +31,16 @@ data class ContractDetailResponse(
 
 data class ContractData(
     val jobTitle: String? = null,
-    val jobType: String? = null,
+    val workType: String? = null,
     val companyName: String? = null,
     val companyEmail: String? = null,
     val companyOwnerName: String? = null,
     val studentName: String? = null,
     val studentEmail: String? = null,
     val studentUniversity: String? = null,
-    val studentCareer: String? = null
+    val studentCareer: String? = null,
+    val startDate: String? = null,
+    val endDate: String? = null,
+    val compensation: String? = null,
+    val clauses: List<String>? = null
 )

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/ContractModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/ContractModels.kt
@@ -1,0 +1,42 @@
+package com.moviles.jobmatch.data.remote.model
+
+data class ContractListResponse(
+    val idContract: Int,
+    val idJob: Int,
+    val jobTitle: String,
+    val idStudent: String,
+    val studentName: String,
+    val companyName: String,
+    val status: String,
+    val createdAt: String,
+    val acceptedAt: String? = null
+)
+
+data class ContractDetailResponse(
+    val idContract: Int,
+    val idApplication: Int,
+    val idJob: Int,
+    val jobTitle: String,
+    val idStudent: String,
+    val studentName: String,
+    val studentEmail: String,
+    val idCompany: String,
+    val companyName: String,
+    val status: String,
+    val contractData: String? = null,
+    val createdAt: String,
+    val updatedAt: String? = null,
+    val acceptedAt: String? = null
+)
+
+data class ContractData(
+    val jobTitle: String? = null,
+    val jobType: String? = null,
+    val companyName: String? = null,
+    val companyEmail: String? = null,
+    val companyOwnerName: String? = null,
+    val studentName: String? = null,
+    val studentEmail: String? = null,
+    val studentUniversity: String? = null,
+    val studentCareer: String? = null
+)

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/ContractModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/ContractModels.kt
@@ -26,7 +26,9 @@ data class ContractDetailResponse(
     val contractData: String? = null,
     val createdAt: String,
     val updatedAt: String? = null,
-    val acceptedAt: String? = null
+    val acceptedAt: String? = null,
+    // Populated by ContractRepository after parsing contractData JSON — not from the API
+    val parsedContractData: ContractData? = null
 )
 
 data class ContractData(

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/AppContainer.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/AppContainer.kt
@@ -26,4 +26,8 @@ object AppContainer {
     val userRepository: UserRepository by lazy {
         UserRepository(RetrofitClient.apiService)
     }
+
+    val contractRepository: ContractRepository by lazy {
+        ContractRepository(RetrofitClient.apiService)
+    }
 }

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/ContractRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/ContractRepository.kt
@@ -1,0 +1,49 @@
+package com.moviles.jobmatch.data.repository
+
+import com.moviles.jobmatch.data.remote.ApiService
+import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
+import com.moviles.jobmatch.data.remote.model.ContractListResponse
+import java.io.IOException
+
+class ContractRepository(private val apiService: ApiService) {
+
+    suspend fun getStudentContracts(): ApiResult<List<ContractListResponse>> {
+        return try {
+            val response = apiService.getStudentContracts()
+            when {
+                response.isSuccessful && response.body() != null ->
+                    ApiResult.Success(response.body()!!)
+                response.code() == 401 ->
+                    ApiResult.Error("No autorizado", 401)
+                response.code() == 403 ->
+                    ApiResult.Error("Acceso denegado", 403)
+                else ->
+                    ApiResult.Error("Error al cargar contratos (${response.code()})", response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado")
+        }
+    }
+
+    suspend fun getContractById(contractId: Int): ApiResult<ContractDetailResponse> {
+        return try {
+            val response = apiService.getContractById(contractId)
+            when {
+                response.isSuccessful && response.body() != null ->
+                    ApiResult.Success(response.body()!!)
+                response.code() == 404 ->
+                    ApiResult.Error("Contrato no encontrado", 404)
+                response.code() == 401 ->
+                    ApiResult.Error("No autorizado", 401)
+                else ->
+                    ApiResult.Error("Error al cargar detalle (${response.code()})", response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado")
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/ContractRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/ContractRepository.kt
@@ -1,11 +1,15 @@
 package com.moviles.jobmatch.data.repository
 
+import com.google.gson.Gson
 import com.moviles.jobmatch.data.remote.ApiService
+import com.moviles.jobmatch.data.remote.model.ContractData
 import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import java.io.IOException
 
 class ContractRepository(private val apiService: ApiService) {
+
+    private val gson = Gson()
 
     suspend fun getStudentContracts(): ApiResult<List<ContractListResponse>> {
         return try {
@@ -31,8 +35,13 @@ class ContractRepository(private val apiService: ApiService) {
         return try {
             val response = apiService.getContractById(contractId)
             when {
-                response.isSuccessful && response.body() != null ->
-                    ApiResult.Success(response.body()!!)
+                response.isSuccessful && response.body() != null -> {
+                    val raw = response.body()!!
+                    val parsed = runCatching {
+                        gson.fromJson(raw.contractData, ContractData::class.java)
+                    }.getOrNull()
+                    ApiResult.Success(raw.copy(parsedContractData = parsed))
+                }
                 response.code() == 404 ->
                     ApiResult.Error("Contrato no encontrado", 404)
                 response.code() == 401 ->

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -498,7 +498,7 @@ private fun ContractCard(contract: ContractListResponse) {
 
                             Column(modifier = Modifier.padding(16.dp)) {
 
-                                // Encabezado del contrato
+                                // Encabezado
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -509,13 +509,17 @@ private fun ContractCard(contract: ContractListResponse) {
                                         style = MaterialTheme.typography.labelMedium,
                                         color = Color(0xFF9AA5B4)
                                     )
-                                    parsedData?.jobType?.let { type ->
+                                    parsedData?.workType?.let { type ->
                                         Surface(
                                             shape = RoundedCornerShape(20.dp),
                                             color = Color(0xFFEFF3FF)
                                         ) {
                                             Text(
-                                                text = if (type == "fixed-time") "Tiempo fijo" else "Autónomo",
+                                                text = when (type.lowercase()) {
+                                                    "fixed-time" -> "Tiempo fijo"
+                                                    "autonomous" -> "Autónomo"
+                                                    else -> type
+                                                },
                                                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
                                                 style = MaterialTheme.typography.labelSmall,
                                                 color = DarkBlue,
@@ -526,12 +530,28 @@ private fun ContractCard(contract: ContractListResponse) {
                                 }
 
                                 Spacer(modifier = Modifier.height(12.dp))
-
-                                // Fechas
                                 ContractDetailRow(label = "Creado", value = formatApplicationDate(detail!!.createdAt))
                                 detail!!.acceptedAt?.let {
                                     Spacer(modifier = Modifier.height(4.dp))
                                     ContractDetailRow(label = "Aceptado", value = formatApplicationDate(it))
+                                }
+
+                                // Vigencia del contrato
+                                if (parsedData?.startDate != null || parsedData?.endDate != null) {
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    val rangeText = when {
+                                        parsedData.startDate != null && parsedData.endDate != null ->
+                                            "${formatApplicationDate(parsedData.startDate)} → ${formatApplicationDate(parsedData.endDate)}"
+                                        parsedData.startDate != null -> "Desde ${formatApplicationDate(parsedData.startDate)}"
+                                        else -> "Hasta ${formatApplicationDate(parsedData.endDate!!)}"
+                                    }
+                                    ContractDetailRow(label = "Vigencia", value = rangeText)
+                                }
+
+                                // Compensación
+                                parsedData?.compensation?.let { comp ->
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    ContractDetailRow(label = "Pago", value = comp)
                                 }
 
                                 Spacer(modifier = Modifier.height(14.dp))
@@ -547,13 +567,13 @@ private fun ContractCard(contract: ContractListResponse) {
                                 )
                                 Spacer(modifier = Modifier.height(6.dp))
                                 ContractDetailRow(label = "Nombre", value = detail!!.companyName)
-                                parsedData?.companyEmail?.let { email ->
+                                parsedData?.companyEmail?.let {
                                     Spacer(modifier = Modifier.height(4.dp))
-                                    ContractDetailRow(label = "Email", value = email)
+                                    ContractDetailRow(label = "Email", value = it)
                                 }
-                                parsedData?.companyOwnerName?.let { owner ->
+                                parsedData?.companyOwnerName?.let {
                                     Spacer(modifier = Modifier.height(4.dp))
-                                    ContractDetailRow(label = "Contacto", value = owner)
+                                    ContractDetailRow(label = "Contacto", value = it)
                                 }
 
                                 Spacer(modifier = Modifier.height(14.dp))
@@ -571,13 +591,50 @@ private fun ContractCard(contract: ContractListResponse) {
                                 ContractDetailRow(label = "Nombre", value = detail!!.studentName)
                                 Spacer(modifier = Modifier.height(4.dp))
                                 ContractDetailRow(label = "Email", value = detail!!.studentEmail)
-                                parsedData?.studentUniversity?.let { uni ->
+                                parsedData?.studentUniversity?.let {
                                     Spacer(modifier = Modifier.height(4.dp))
-                                    ContractDetailRow(label = "Universidad", value = uni)
+                                    ContractDetailRow(label = "Universidad", value = it)
                                 }
-                                parsedData?.studentCareer?.let { career ->
+                                parsedData?.studentCareer?.let {
                                     Spacer(modifier = Modifier.height(4.dp))
-                                    ContractDetailRow(label = "Carrera", value = career)
+                                    ContractDetailRow(label = "Carrera", value = it)
+                                }
+
+                                // Cláusulas
+                                val clauses = parsedData?.clauses
+                                if (!clauses.isNullOrEmpty()) {
+                                    Spacer(modifier = Modifier.height(14.dp))
+                                    Divider(color = Color(0xFFF0F2F5))
+                                    Spacer(modifier = Modifier.height(14.dp))
+                                    Text(
+                                        text = "Términos y condiciones",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = DarkBlue
+                                    )
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    clauses.forEachIndexed { index, clause ->
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(bottom = 6.dp),
+                                            verticalAlignment = Alignment.Top
+                                        ) {
+                                            Text(
+                                                text = "${index + 1}.",
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = DarkBlue,
+                                                fontWeight = FontWeight.SemiBold,
+                                                modifier = Modifier.width(20.dp)
+                                            )
+                                            Text(
+                                                text = clause,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = Color(0xFF1A2332),
+                                                modifier = Modifier.weight(1f)
+                                            )
+                                        }
+                                    }
                                 }
 
                                 // TODO: Botones de aceptar/rechazar contrato

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -1,6 +1,15 @@
 package com.moviles.jobmatch.ui.screens.profile
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.rememberCoroutineScope
+import com.google.gson.Gson
+import com.moviles.jobmatch.data.remote.model.ContractData
+import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
+import com.moviles.jobmatch.data.repository.ApiResult
+import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +29,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.TrendingUp
@@ -27,10 +37,12 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,12 +52,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.remote.model.AvailabilityResponse
+import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.DayAvailabilitySelector
 import com.moviles.jobmatch.ui.components.DeleteAccountDialog
@@ -56,6 +71,7 @@ import com.moviles.jobmatch.ui.components.SkillChip
 import com.moviles.jobmatch.ui.components.StatCard
 import com.moviles.jobmatch.ui.components.StudentProfileHeader
 import com.moviles.jobmatch.ui.theme.DarkBlue
+import com.moviles.jobmatch.ui.utils.formatApplicationDate
 
 @Composable
 fun StudentProfileScreen(
@@ -63,7 +79,7 @@ fun StudentProfileScreen(
     onAccountDeleted: () -> Unit = {}
 ) {
     val viewModel: StudentProfileViewModel = viewModel(
-        factory = StudentProfileViewModelFactory(AppContainer.studentRepository)
+        factory = StudentProfileViewModelFactory(AppContainer.studentRepository, AppContainer.contractRepository)
     )
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -121,6 +137,7 @@ fun StudentProfileScreen(
                 val student = uiState.student
                 val availabilityDays = student?.availability.toSelectedDays()
                 val skills = student?.skills ?: emptyList()
+                val contracts = uiState.contracts
 
                 Column(
                     modifier = Modifier
@@ -271,6 +288,43 @@ fun StudentProfileScreen(
 
                     Spacer(modifier = Modifier.height(16.dp))
 
+                    // --- Mis Contratos ---
+                    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                        SectionHeader(title = "Mis Contratos")
+                        Spacer(modifier = Modifier.height(8.dp))
+                        when {
+                            uiState.isLoadingContracts -> {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(64.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator(
+                                        color = DarkBlue,
+                                        modifier = Modifier.size(28.dp)
+                                    )
+                                }
+                            }
+                            contracts.isEmpty() -> {
+                                Text(
+                                    text = "Sin contratos registrados",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color(0xFF9AA5B4)
+                                )
+                            }
+                            else -> {
+                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    contracts.forEach { contract ->
+                                        ContractCard(contract = contract)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
                     // --- Footer ---
                     Column(modifier = Modifier.padding(horizontal = 16.dp)) {
                         student?.user?.phone?.let { phone ->
@@ -338,6 +392,245 @@ fun StudentProfileScreen(
                 showDeleteDialog = false
                 deleteViewModel.clearError()
             }
+        )
+    }
+}
+
+@Composable
+private fun ContractCard(contract: ContractListResponse) {
+    var expanded by remember { mutableStateOf(false) }
+    var isLoadingDetail by remember { mutableStateOf(false) }
+    var detail by remember { mutableStateOf<ContractDetailResponse?>(null) }
+    val scope = rememberCoroutineScope()
+    val gson = remember { Gson() }
+
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "chevron"
+    )
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column {
+            // --- Fila principal (siempre visible) ---
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        expanded = !expanded
+                        if (expanded && detail == null) {
+                            scope.launch {
+                                isLoadingDetail = true
+                                when (val result = AppContainer.contractRepository.getContractById(contract.idContract)) {
+                                    is ApiResult.Success -> detail = result.data
+                                    is ApiResult.Error -> Unit
+                                }
+                                isLoadingDetail = false
+                            }
+                        }
+                    }
+                    .padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = contract.jobTitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color(0xFF1A2332)
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = contract.companyName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color(0xFF5A6A7A)
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = formatApplicationDate(contract.createdAt),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color(0xFF9AA5B4)
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                ContractStatusBadge(status = contract.status)
+                Spacer(modifier = Modifier.width(6.dp))
+                Icon(
+                    imageVector = Icons.Default.ExpandMore,
+                    contentDescription = if (expanded) "Contraer" else "Expandir",
+                    modifier = Modifier
+                        .size(20.dp)
+                        .rotate(chevronRotation),
+                    tint = Color(0xFF9AA5B4)
+                )
+            }
+
+            // --- Sección expandible ---
+            AnimatedVisibility(visible = expanded) {
+                Column {
+                    Divider(color = Color(0xFFF0F2F5), thickness = 1.dp)
+
+                    when {
+                        isLoadingDetail -> {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(20.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator(
+                                    color = DarkBlue,
+                                    modifier = Modifier.size(24.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            }
+                        }
+
+                        detail != null -> {
+                            val parsedData = runCatching {
+                                gson.fromJson(detail!!.contractData, ContractData::class.java)
+                            }.getOrNull()
+
+                            Column(modifier = Modifier.padding(16.dp)) {
+
+                                // Encabezado del contrato
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        text = "Contrato #${detail!!.idContract}",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = Color(0xFF9AA5B4)
+                                    )
+                                    parsedData?.jobType?.let { type ->
+                                        Surface(
+                                            shape = RoundedCornerShape(20.dp),
+                                            color = Color(0xFFEFF3FF)
+                                        ) {
+                                            Text(
+                                                text = if (type == "fixed-time") "Tiempo fijo" else "Autónomo",
+                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = DarkBlue,
+                                                fontWeight = FontWeight.Medium
+                                            )
+                                        }
+                                    }
+                                }
+
+                                Spacer(modifier = Modifier.height(12.dp))
+
+                                // Fechas
+                                ContractDetailRow(label = "Creado", value = formatApplicationDate(detail!!.createdAt))
+                                detail!!.acceptedAt?.let {
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    ContractDetailRow(label = "Aceptado", value = formatApplicationDate(it))
+                                }
+
+                                Spacer(modifier = Modifier.height(14.dp))
+                                Divider(color = Color(0xFFF0F2F5))
+                                Spacer(modifier = Modifier.height(14.dp))
+
+                                // Empresa
+                                Text(
+                                    text = "Empresa",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = DarkBlue
+                                )
+                                Spacer(modifier = Modifier.height(6.dp))
+                                ContractDetailRow(label = "Nombre", value = detail!!.companyName)
+                                parsedData?.companyEmail?.let { email ->
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    ContractDetailRow(label = "Email", value = email)
+                                }
+                                parsedData?.companyOwnerName?.let { owner ->
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    ContractDetailRow(label = "Contacto", value = owner)
+                                }
+
+                                Spacer(modifier = Modifier.height(14.dp))
+                                Divider(color = Color(0xFFF0F2F5))
+                                Spacer(modifier = Modifier.height(14.dp))
+
+                                // Estudiante
+                                Text(
+                                    text = "Estudiante",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = DarkBlue
+                                )
+                                Spacer(modifier = Modifier.height(6.dp))
+                                ContractDetailRow(label = "Nombre", value = detail!!.studentName)
+                                Spacer(modifier = Modifier.height(4.dp))
+                                ContractDetailRow(label = "Email", value = detail!!.studentEmail)
+                                parsedData?.studentUniversity?.let { uni ->
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    ContractDetailRow(label = "Universidad", value = uni)
+                                }
+                                parsedData?.studentCareer?.let { career ->
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    ContractDetailRow(label = "Carrera", value = career)
+                                }
+
+                                // TODO: Botones de aceptar/rechazar contrato
+                                // Implementar aquí si contract.status == "pending"
+                                // Endpoint: PUT /contracts/{contractId}/accept
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContractDetailRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "$label: ",
+            style = MaterialTheme.typography.bodySmall,
+            color = Color(0xFF9AA5B4),
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.width(90.dp)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = Color(0xFF1A2332),
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun ContractStatusBadge(status: String) {
+    val (backgroundColor, textColor, label) = when (status.lowercase()) {
+        "pending" -> Triple(Color(0xFFFFF3E0), Color(0xFFF57C00), "Pendiente")
+        "accepted", "active" -> Triple(Color(0xFFE8F5E9), Color(0xFF388E3C), "Activo")
+        "completed" -> Triple(Color(0xFFE3F2FD), Color(0xFF1565C0), "Completado")
+        "cancelled" -> Triple(Color(0xFFFFEBEE), Color(0xFFC62828), "Cancelado")
+        else -> Triple(Color(0xFFF5F5F5), Color(0xFF757575), status)
+    }
+    Surface(
+        shape = RoundedCornerShape(20.dp),
+        color = backgroundColor
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium,
+            color = textColor,
+            fontSize = 11.sp
         )
     }
 }

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -4,12 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
-import androidx.compose.runtime.rememberCoroutineScope
-import com.google.gson.Gson
-import com.moviles.jobmatch.data.remote.model.ContractData
 import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
-import com.moviles.jobmatch.data.repository.ApiResult
-import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,7 +32,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -61,7 +56,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.remote.model.AvailabilityResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
-import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.DayAvailabilitySelector
 import com.moviles.jobmatch.ui.components.DeleteAccountDialog
 import com.moviles.jobmatch.ui.components.InfoRow
@@ -306,6 +300,13 @@ fun StudentProfileScreen(
                                     )
                                 }
                             }
+                            uiState.contractsErrorMessage != null -> {
+                                Text(
+                                    text = uiState.contractsErrorMessage,
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
                             contracts.isEmpty() -> {
                                 Text(
                                     text = "Sin contratos registrados",
@@ -316,7 +317,13 @@ fun StudentProfileScreen(
                             else -> {
                                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                     contracts.forEach { contract ->
-                                        ContractCard(contract = contract)
+                                        ContractCard(
+                                            contract = contract,
+                                            detail = uiState.contractDetails[contract.idContract],
+                                            isLoadingDetail = contract.idContract in uiState.loadingContractIds,
+                                            detailError = uiState.contractDetailErrors[contract.idContract],
+                                            onExpand = { viewModel.loadContractDetail(contract.idContract) }
+                                        )
                                     }
                                 }
                             }
@@ -397,12 +404,14 @@ fun StudentProfileScreen(
 }
 
 @Composable
-private fun ContractCard(contract: ContractListResponse) {
+private fun ContractCard(
+    contract: ContractListResponse,
+    detail: ContractDetailResponse?,
+    isLoadingDetail: Boolean,
+    detailError: String?,
+    onExpand: () -> Unit
+) {
     var expanded by remember { mutableStateOf(false) }
-    var isLoadingDetail by remember { mutableStateOf(false) }
-    var detail by remember { mutableStateOf<ContractDetailResponse?>(null) }
-    val scope = rememberCoroutineScope()
-    val gson = remember { Gson() }
 
     val chevronRotation by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
@@ -416,22 +425,13 @@ private fun ContractCard(contract: ContractListResponse) {
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
     ) {
         Column {
-            // --- Fila principal (siempre visible) ---
+            // --- Main row (always visible) ---
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable {
                         expanded = !expanded
-                        if (expanded && detail == null) {
-                            scope.launch {
-                                isLoadingDetail = true
-                                when (val result = AppContainer.contractRepository.getContractById(contract.idContract)) {
-                                    is ApiResult.Success -> detail = result.data
-                                    is ApiResult.Error -> Unit
-                                }
-                                isLoadingDetail = false
-                            }
-                        }
+                        if (expanded) onExpand()
                     }
                     .padding(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -470,10 +470,10 @@ private fun ContractCard(contract: ContractListResponse) {
                 )
             }
 
-            // --- Sección expandible ---
+            // --- Expandable section ---
             AnimatedVisibility(visible = expanded) {
                 Column {
-                    Divider(color = Color(0xFFF0F2F5), thickness = 1.dp)
+                    HorizontalDivider(color = Color(0xFFF0F2F5), thickness = 1.dp)
 
                     when {
                         isLoadingDetail -> {
@@ -491,21 +491,28 @@ private fun ContractCard(contract: ContractListResponse) {
                             }
                         }
 
+                        detailError != null -> {
+                            Text(
+                                text = detailError,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.padding(16.dp)
+                            )
+                        }
+
                         detail != null -> {
-                            val parsedData = runCatching {
-                                gson.fromJson(detail!!.contractData, ContractData::class.java)
-                            }.getOrNull()
+                            val parsedData = detail.parsedContractData
 
                             Column(modifier = Modifier.padding(16.dp)) {
 
-                                // Encabezado
+                                // Header
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.SpaceBetween,
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     Text(
-                                        text = "Contrato #${detail!!.idContract}",
+                                        text = "Contrato #${detail.idContract}",
                                         style = MaterialTheme.typography.labelMedium,
                                         color = Color(0xFF9AA5B4)
                                     )
@@ -530,13 +537,13 @@ private fun ContractCard(contract: ContractListResponse) {
                                 }
 
                                 Spacer(modifier = Modifier.height(12.dp))
-                                ContractDetailRow(label = "Creado", value = formatApplicationDate(detail!!.createdAt))
-                                detail!!.acceptedAt?.let {
+                                ContractDetailRow(label = "Creado", value = formatApplicationDate(detail.createdAt))
+                                detail.acceptedAt?.let {
                                     Spacer(modifier = Modifier.height(4.dp))
                                     ContractDetailRow(label = "Aceptado", value = formatApplicationDate(it))
                                 }
 
-                                // Vigencia del contrato
+                                // Contract period
                                 if (parsedData?.startDate != null || parsedData?.endDate != null) {
                                     Spacer(modifier = Modifier.height(4.dp))
                                     val rangeText = when {
@@ -548,17 +555,17 @@ private fun ContractCard(contract: ContractListResponse) {
                                     ContractDetailRow(label = "Vigencia", value = rangeText)
                                 }
 
-                                // Compensación
+                                // Compensation
                                 parsedData?.compensation?.let { comp ->
                                     Spacer(modifier = Modifier.height(4.dp))
                                     ContractDetailRow(label = "Pago", value = comp)
                                 }
 
                                 Spacer(modifier = Modifier.height(14.dp))
-                                Divider(color = Color(0xFFF0F2F5))
+                                HorizontalDivider(color = Color(0xFFF0F2F5))
                                 Spacer(modifier = Modifier.height(14.dp))
 
-                                // Empresa
+                                // Company
                                 Text(
                                     text = "Empresa",
                                     style = MaterialTheme.typography.labelMedium,
@@ -566,7 +573,7 @@ private fun ContractCard(contract: ContractListResponse) {
                                     color = DarkBlue
                                 )
                                 Spacer(modifier = Modifier.height(6.dp))
-                                ContractDetailRow(label = "Nombre", value = detail!!.companyName)
+                                ContractDetailRow(label = "Nombre", value = detail.companyName)
                                 parsedData?.companyEmail?.let {
                                     Spacer(modifier = Modifier.height(4.dp))
                                     ContractDetailRow(label = "Email", value = it)
@@ -577,10 +584,10 @@ private fun ContractCard(contract: ContractListResponse) {
                                 }
 
                                 Spacer(modifier = Modifier.height(14.dp))
-                                Divider(color = Color(0xFFF0F2F5))
+                                HorizontalDivider(color = Color(0xFFF0F2F5))
                                 Spacer(modifier = Modifier.height(14.dp))
 
-                                // Estudiante
+                                // Student
                                 Text(
                                     text = "Estudiante",
                                     style = MaterialTheme.typography.labelMedium,
@@ -588,9 +595,9 @@ private fun ContractCard(contract: ContractListResponse) {
                                     color = DarkBlue
                                 )
                                 Spacer(modifier = Modifier.height(6.dp))
-                                ContractDetailRow(label = "Nombre", value = detail!!.studentName)
+                                ContractDetailRow(label = "Nombre", value = detail.studentName)
                                 Spacer(modifier = Modifier.height(4.dp))
-                                ContractDetailRow(label = "Email", value = detail!!.studentEmail)
+                                ContractDetailRow(label = "Email", value = detail.studentEmail)
                                 parsedData?.studentUniversity?.let {
                                     Spacer(modifier = Modifier.height(4.dp))
                                     ContractDetailRow(label = "Universidad", value = it)
@@ -600,11 +607,11 @@ private fun ContractCard(contract: ContractListResponse) {
                                     ContractDetailRow(label = "Carrera", value = it)
                                 }
 
-                                // Cláusulas
+                                // Clauses
                                 val clauses = parsedData?.clauses
                                 if (!clauses.isNullOrEmpty()) {
                                     Spacer(modifier = Modifier.height(14.dp))
-                                    Divider(color = Color(0xFFF0F2F5))
+                                    HorizontalDivider(color = Color(0xFFF0F2F5))
                                     Spacer(modifier = Modifier.height(14.dp))
                                     Text(
                                         text = "Términos y condiciones",
@@ -637,8 +644,7 @@ private fun ContractCard(contract: ContractListResponse) {
                                     }
                                 }
 
-                                // TODO: Botones de aceptar/rechazar contrato
-                                // Implementar aquí si contract.status == "pending"
+                                // TODO: Accept/reject buttons when contract.status == "pending"
                                 // Endpoint: PUT /contracts/{contractId}/accept
                             }
                         }

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -56,6 +56,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.remote.model.AvailabilityResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
+import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.DayAvailabilitySelector
 import com.moviles.jobmatch.ui.components.DeleteAccountDialog
 import com.moviles.jobmatch.ui.components.InfoRow
@@ -302,7 +303,7 @@ fun StudentProfileScreen(
                             }
                             uiState.contractsErrorMessage != null -> {
                                 Text(
-                                    text = uiState.contractsErrorMessage,
+                                    text = uiState.contractsErrorMessage!!,
                                     color = MaterialTheme.colorScheme.error,
                                     style = MaterialTheme.typography.bodyMedium
                                 )

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileViewModel.kt
@@ -4,9 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.moviles.jobmatch.data.AuthSession
+import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
 import com.moviles.jobmatch.data.repository.ApiResult
+import com.moviles.jobmatch.data.repository.ContractRepository
 import com.moviles.jobmatch.data.repository.StudentRepository
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,10 +19,15 @@ import kotlinx.coroutines.launch
 data class StudentProfileUiState(
     val isLoading: Boolean = false,
     val student: StudentProfileResponse? = null,
+    val contracts: List<ContractListResponse> = emptyList(),
+    val isLoadingContracts: Boolean = false,
     val errorMessage: String? = null
 )
 
-class StudentProfileViewModel(private val studentRepository: StudentRepository) : ViewModel() {
+class StudentProfileViewModel(
+    private val studentRepository: StudentRepository,
+    private val contractRepository: ContractRepository
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(StudentProfileUiState())
     val uiState: StateFlow<StudentProfileUiState> = _uiState.asStateFlow()
@@ -31,24 +39,36 @@ class StudentProfileViewModel(private val studentRepository: StudentRepository) 
     fun loadProfile() {
         val studentId = AuthSession.currentUser?.userId ?: return
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
-            when (val result = studentRepository.getStudentProfile(studentId)) {
+            _uiState.update { it.copy(isLoading = true, isLoadingContracts = true, errorMessage = null) }
+
+            val profileDeferred = async { studentRepository.getStudentProfile(studentId) }
+            val contractsDeferred = async { contractRepository.getStudentContracts() }
+
+            when (val result = profileDeferred.await()) {
                 is ApiResult.Success ->
                     _uiState.update { it.copy(isLoading = false, student = result.data) }
                 is ApiResult.Error ->
                     _uiState.update { it.copy(isLoading = false, errorMessage = result.message) }
+            }
+
+            when (val result = contractsDeferred.await()) {
+                is ApiResult.Success ->
+                    _uiState.update { it.copy(isLoadingContracts = false, contracts = result.data) }
+                is ApiResult.Error ->
+                    _uiState.update { it.copy(isLoadingContracts = false) }
             }
         }
     }
 }
 
 class StudentProfileViewModelFactory(
-    private val studentRepository: StudentRepository
+    private val studentRepository: StudentRepository,
+    private val contractRepository: ContractRepository
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(StudentProfileViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return StudentProfileViewModel(studentRepository) as T
+            return StudentProfileViewModel(studentRepository, contractRepository) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
     }

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.moviles.jobmatch.data.AuthSession
+import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
 import com.moviles.jobmatch.data.repository.ApiResult
@@ -21,6 +22,10 @@ data class StudentProfileUiState(
     val student: StudentProfileResponse? = null,
     val contracts: List<ContractListResponse> = emptyList(),
     val isLoadingContracts: Boolean = false,
+    val contractDetails: Map<Int, ContractDetailResponse> = emptyMap(),
+    val contractDetailErrors: Map<Int, String> = emptyMap(),
+    val loadingContractIds: Set<Int> = emptySet(),
+    val contractsErrorMessage: String? = null,
     val errorMessage: String? = null
 )
 
@@ -55,7 +60,29 @@ class StudentProfileViewModel(
                 is ApiResult.Success ->
                     _uiState.update { it.copy(isLoadingContracts = false, contracts = result.data) }
                 is ApiResult.Error ->
-                    _uiState.update { it.copy(isLoadingContracts = false) }
+                    _uiState.update { it.copy(isLoadingContracts = false, contractsErrorMessage = result.message) }
+            }
+        }
+    }
+
+    fun loadContractDetail(contractId: Int) {
+        if (_uiState.value.contractDetails.containsKey(contractId) ||
+            _uiState.value.loadingContractIds.contains(contractId)) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(loadingContractIds = it.loadingContractIds + contractId) }
+            when (val result = contractRepository.getContractById(contractId)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        contractDetails = it.contractDetails + (contractId to result.data),
+                        loadingContractIds = it.loadingContractIds - contractId
+                    )
+                }
+                is ApiResult.Error -> _uiState.update {
+                    it.copy(
+                        contractDetailErrors = it.contractDetailErrors + (contractId to result.message),
+                        loadingContractIds = it.loadingContractIds - contractId
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
# Pull Request

## Description
This PR implements the My Contracts section in the Student Profile screen for the JobMatch mobile app (issue #67).

Students can now view all their contracts directly from their profile. Each contract displays the job title, company name, current status, and creation date. Tapping a card expands it to reveal the full contract detail fetched from the API — including company information, student information, job type, validity dates, compensation, and the full list of contract terms and conditions — giving the student everything they need to make an informed decision before accepting.

---

## Related Issue

Closes #67 

---

## Changes Included

### Frontend / Mobile Changes

* [x] Added new screen(s)
* [x] Added ViewModel(s)
* [x] Added navigation
* [x] Added API integration
* [x] Added loading/error states
* [x] Added validation
* [x] Updated UI components
* [ ] Other:

---

## Architecture

UI (StudentProfileScreen — ContractCard)
  → ViewModel (StudentProfileViewModel)
    → Repository (ContractRepository)
      → API (ApiService — GET /contracts/student + GET /contracts/{contractId})
ContractRepository wraps both endpoints with ApiResult<T> error handling, matching the existing repository pattern.
StudentProfileViewModel fetches contracts and profile in parallel with async {} to avoid sequential loading delays.
Contract detail is fetched lazily on first expand and cached in local remember state — no repeated network calls on re-open.
State managed via MutableStateFlow<StudentProfileUiState> collected with collectAsStateWithLifecycle().
ViewModel Factory receives StudentRepository and ContractRepository from AppContainer, consistent with the rest of the project.

---

## API / Database Changes

Describe any endpoint, request/response model, or database changes.

---

## Testing Performed

 Tested manually on physical device (Samsung SM-A515U1)
 Contracts section appears in student profile after "Experiencia Reciente"
 Loading spinner shown while contracts list is being fetched
 Empty state shown when student has no contracts
 Card expands on tap with chevron animation
 Spinner shown while loading contract detail on first expand
 Detail shows: job type badge, validity dates, compensation, company info, student info, and numbered terms
 Status badge renders correct color — Pendiente (orange), Activo (green), Completado (blue), Cancelado (red)
 Re-opening a card does not trigger a second API call
 No crashes detected

---

## Evidence

<img width="1200" height="1600" alt="image" src="https://github.com/user-attachments/assets/29d917ef-2f48-4d97-a389-8721afd80de1" />

<img width="900" height="1600" alt="image" src="https://github.com/user-attachments/assets/dfe76cc7-c7e1-4c79-bcb1-894615cc3c3d" />

<img width="900" height="1600" alt="image" src="https://github.com/user-attachments/assets/6634f06b-2b34-48e0-b01f-49ae62f7334c" />

---

## Notes

The accept/reject contract action is not implemented in this PR — that functionality is assigned to a separate collaborator.

The expanded card includes a clearly marked TODO indicating exactly where the buttons go and which endpoint to call:


// TODO: Botones de aceptar/rechazar contrato
// Implementar aquí si contract.status == "pending"
// Endpoint: PUT /contracts/{contractId}/accept
Full contract flow for reference:


Student applies        → POST /applications          → Application (pending)
Company accepts        → PUT  /applications/{id}     → Contract auto-generated (pending)
Student views contract ← this PR
Student accepts        → PUT  /contracts/{id}/accept → Contract (active)  ← next PR
