### PR TITLE
Accept contract 

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -19,6 +19,7 @@ import com.moviles.jobmatch.data.remote.model.UpdateApplicationRequest
 import com.moviles.jobmatch.data.remote.model.UpdateApplicationResponse
 import com.moviles.jobmatch.data.remote.model.UpdateJobRequest
 import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
+import com.moviles.jobmatch.data.remote.model.ContractAcceptResponse
 import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.remote.model.DeleteUserRequest
@@ -84,6 +85,9 @@ interface ApiService {
 
     @GET("contracts/{contractId}")
     suspend fun getContractById(@Path("contractId") contractId: Int): Response<ContractDetailResponse>
+
+    @PUT("contracts/{contractId}/accept")
+    suspend fun acceptContract(@Path("contractId") contractId: Int): Response<ContractAcceptResponse>
 
     @HTTP(method = "DELETE", path = "users/{userId}", hasBody = true)
     suspend fun deleteUser(

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/ContractModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/ContractModels.kt
@@ -31,6 +31,24 @@ data class ContractDetailResponse(
     val parsedContractData: ContractData? = null
 )
 
+data class ContractResponse(
+    val idContract: Int,
+    val idApplication: Int,
+    val idJob: Int,
+    val idStudent: String,
+    val idCompany: String,
+    val status: String,
+    val createdAt: String,
+    val updatedAt: String? = null,
+    val acceptedAt: String? = null,
+    val contractData: String? = null
+)
+
+data class ContractAcceptResponse(
+    val contract: ContractResponse,
+    val message: String
+)
+
 data class ContractData(
     val jobTitle: String? = null,
     val workType: String? = null,

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/ContractRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/ContractRepository.kt
@@ -2,6 +2,7 @@ package com.moviles.jobmatch.data.repository
 
 import com.google.gson.Gson
 import com.moviles.jobmatch.data.remote.ApiService
+import com.moviles.jobmatch.data.remote.model.ContractAcceptResponse
 import com.moviles.jobmatch.data.remote.model.ContractData
 import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
@@ -48,6 +49,30 @@ class ContractRepository(private val apiService: ApiService) {
                     ApiResult.Error("No autorizado", 401)
                 else ->
                     ApiResult.Error("Error al cargar detalle (${response.code()})", response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado")
+        }
+    }
+
+    suspend fun acceptContract(contractId: Int): ApiResult<ContractAcceptResponse> {
+        return try {
+            val response = apiService.acceptContract(contractId)
+            when {
+                response.isSuccessful && response.body() != null ->
+                    ApiResult.Success(response.body()!!)
+                response.code() == 404 ->
+                    ApiResult.Error("Contrato no encontrado", 404)
+                response.code() == 401 ->
+                    ApiResult.Error("No autorizado", 401)
+                response.code() == 403 ->
+                    ApiResult.Error("No tenés permiso para aceptar este contrato", 403)
+                response.code() == 400 ->
+                    ApiResult.Error("El contrato ya fue aceptado o no está pendiente", 400)
+                else ->
+                    ApiResult.Error("Error al aceptar el contrato (${response.code()})", response.code())
             }
         } catch (e: IOException) {
             ApiResult.Error("No se pudo conectar al servidor")

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -28,9 +28,11 @@ import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -323,7 +325,10 @@ fun StudentProfileScreen(
                                             detail = uiState.contractDetails[contract.idContract],
                                             isLoadingDetail = contract.idContract in uiState.loadingContractIds,
                                             detailError = uiState.contractDetailErrors[contract.idContract],
-                                            onExpand = { viewModel.loadContractDetail(contract.idContract) }
+                                            isAccepting = contract.idContract in uiState.acceptingContractIds,
+                                            acceptError = uiState.contractAcceptErrors[contract.idContract],
+                                            onExpand = { viewModel.loadContractDetail(contract.idContract) },
+                                            onAccept = { viewModel.acceptContract(contract.idContract) }
                                         )
                                     }
                                 }
@@ -410,9 +415,13 @@ private fun ContractCard(
     detail: ContractDetailResponse?,
     isLoadingDetail: Boolean,
     detailError: String?,
-    onExpand: () -> Unit
+    isAccepting: Boolean,
+    acceptError: String?,
+    onExpand: () -> Unit,
+    onAccept: () -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
+    var termsAccepted by remember { mutableStateOf(false) }
 
     val chevronRotation by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
@@ -645,8 +654,60 @@ private fun ContractCard(
                                     }
                                 }
 
-                                // TODO: Accept/reject buttons when contract.status == "pending"
-                                // Endpoint: PUT /contracts/{contractId}/accept
+                                // Accept contract
+                                if (contract.status.equals("pending", ignoreCase = true)) {
+                                    Spacer(modifier = Modifier.height(14.dp))
+                                    HorizontalDivider(color = Color(0xFFF0F2F5))
+                                    Spacer(modifier = Modifier.height(14.dp))
+
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable(enabled = !isAccepting) {
+                                                termsAccepted = !termsAccepted
+                                            }
+                                    ) {
+                                        Checkbox(
+                                            checked = termsAccepted,
+                                            onCheckedChange = { termsAccepted = it },
+                                            enabled = !isAccepting
+                                        )
+                                        Text(
+                                            text = "He leído y acepto los términos del contrato.",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = Color(0xFF1A2332)
+                                        )
+                                    }
+
+                                    if (acceptError != null) {
+                                        Spacer(modifier = Modifier.height(4.dp))
+                                        Text(
+                                            text = acceptError,
+                                            color = MaterialTheme.colorScheme.error,
+                                            style = MaterialTheme.typography.bodySmall
+                                        )
+                                    }
+
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Button(
+                                        onClick = onAccept,
+                                        enabled = termsAccepted && !isAccepting,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        shape = RoundedCornerShape(10.dp),
+                                        colors = ButtonDefaults.buttonColors(containerColor = DarkBlue)
+                                    ) {
+                                        if (isAccepting) {
+                                            CircularProgressIndicator(
+                                                color = Color.White,
+                                                modifier = Modifier.size(18.dp),
+                                                strokeWidth = 2.dp
+                                            )
+                                        } else {
+                                            Text("Aceptar contrato")
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileViewModel.kt
@@ -25,6 +25,8 @@ data class StudentProfileUiState(
     val contractDetails: Map<Int, ContractDetailResponse> = emptyMap(),
     val contractDetailErrors: Map<Int, String> = emptyMap(),
     val loadingContractIds: Set<Int> = emptySet(),
+    val acceptingContractIds: Set<Int> = emptySet(),
+    val contractAcceptErrors: Map<Int, String> = emptyMap(),
     val contractsErrorMessage: String? = null,
     val errorMessage: String? = null
 )
@@ -81,6 +83,40 @@ class StudentProfileViewModel(
                     it.copy(
                         contractDetailErrors = it.contractDetailErrors + (contractId to result.message),
                         loadingContractIds = it.loadingContractIds - contractId
+                    )
+                }
+            }
+        }
+    }
+
+    fun acceptContract(contractId: Int) {
+        if (_uiState.value.acceptingContractIds.contains(contractId)) return
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    acceptingContractIds = it.acceptingContractIds + contractId,
+                    contractAcceptErrors = it.contractAcceptErrors - contractId
+                )
+            }
+            when (val result = contractRepository.acceptContract(contractId)) {
+                is ApiResult.Success -> _uiState.update { state ->
+                    state.copy(
+                        acceptingContractIds = state.acceptingContractIds - contractId,
+                        contracts = state.contracts.map { contract ->
+                            if (contract.idContract == contractId) {
+                                contract.copy(
+                                    status = result.data.contract.status,
+                                    acceptedAt = result.data.contract.acceptedAt
+                                )
+                            } else contract
+                        },
+                        contractDetails = state.contractDetails - contractId
+                    )
+                }
+                is ApiResult.Error -> _uiState.update {
+                    it.copy(
+                        acceptingContractIds = it.acceptingContractIds - contractId,
+                        contractAcceptErrors = it.contractAcceptErrors + (contractId to result.message)
                     )
                 }
             }


### PR DESCRIPTION
# Pull Request

## Description

Implements issue #17 (Accept contract) in the Android frontend. Students can now read the contract terms and explicitly accept a pending contract from their profile screen. On acceptance, the contract status updates to "active" and the associated job moves to "in-progress" (handled server-side via the existing PUT /contracts/{contractId}/accept endpoint).

---

## Related Issue

Closes #17

---

## Changes Included

### Backend Changes

* [ ] Added new endpoint(s)
* [ ] Added/updated DTOs
* [ ] Added/updated services
* [ ] Added/updated repositories
* [ ] Added/updated database migrations
* [ ] Added validations
* [ ] Added exception handling
* [ ] Other:

### Frontend / Mobile Changes

* [ ] Added new screen(s)
* [ ] Added ViewModel(s)
* [x] Added navigation
* [x] Added API integration
* [x] Added loading/error states
* [x] Added validation
* [x] Updated UI components
* [ ] Other:

---

## Architecture

UI (StudentProfileScreen — ContractCard)
  → ViewModel (StudentProfileViewModel.acceptContract)
    → Repository (ContractRepository.acceptContract)
      → API (ApiService — PUT contracts/{contractId}/accept)
StudentProfileViewModel tracks per-contract acceptingContractIds (loading) and contractAcceptErrors (error) state, and on success patches the contract's status/acceptedAt directly in the local contracts list — no full reload needed. The cached contract detail for that id is invalidated so it refetches the updated detail on next expand

---

## API / Database Changes

Describe any endpoint, request/response model, or database changes.

---

## Testing Performed

* [x] Feature tested manually
* [x] Navigation tested
* [x] Error handling tested
* [x] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

Checkbox + "Aceptar contrato" button only appear when contract.status == "pending".
Button stays disabled until the checkbox is checked.
Tapping it shows a spinner, then on success the card updates to show the "Activo" status badge and the checkbox/button disappear (since status is no longer "pending").
Confirmed in the database that the contract moved to active and the related job moved to in-progress.
Tested the reject/error path by forcing a duplicate accept call on an already-active contract → backend returns 400, error message rendered inline in the card.
Verified end-to-end against a real running backend (not mocked).

---

## Evidence

### Screenshots / Videos



<img width="326" height="573" alt="Captura de pantalla 2026-06-18 190819" src="https://github.com/user-attachments/assets/74462247-c5aa-4344-b795-9016aaf0240e" />
<img width="356" height="622" alt="Captura de pantalla 2026-06-18 190832" src="https://github.com/user-attachments/assets/31a81711-fc42-41df-85e4-303b480f2472" />
<img width="316" height="490" alt="Captura de pantalla 2026-06-18 190416" src="https://github.com/user-attachments/assets/3f1a97b9-7a53-458d-9c84-c83877afc05f" />

---

## Notes

The accept action only updates the tapped contract's entry in local state — it does not trigger a full profile reload, keeping the UX snappy and avoiding unnecessary network calls.