### PR TITLE
Feature/company contracts issue 71

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -84,7 +84,7 @@ interface ApiService {
     @GET("contracts/student")
     suspend fun getStudentContracts(): Response<List<ContractListResponse>>
 
-    @GET("contracts/company")
+    @GET("contracts")
     suspend fun getCompanyContracts(
         @Query("status") status: String? = null
     ): Response<List<ContractListResponse>>

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -31,6 +31,7 @@ import retrofit2.http.HTTP
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface ApiService {
     @POST(AppConstants.Api.Paths.AUTH_LOGIN)
@@ -82,6 +83,11 @@ interface ApiService {
 
     @GET("contracts/student")
     suspend fun getStudentContracts(): Response<List<ContractListResponse>>
+
+    @GET("contracts/company")
+    suspend fun getCompanyContracts(
+        @Query("status") status: String? = null
+    ): Response<List<ContractListResponse>>
 
     @GET("contracts/{contractId}")
     suspend fun getContractById(@Path("contractId") contractId: Int): Response<ContractDetailResponse>

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/StudentModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/StudentModels.kt
@@ -26,13 +26,18 @@ data class UserProfileResponse(
     val active: Boolean
 )
 
+data class SkillResponse(
+    val skillId: String,
+    val skillName: String
+)
+
 data class StudentProfileResponse(
     val id: String,
     val user: UserProfileResponse,
     val university: String,
     val career: String,
     val studentId: String,
-    val skills: List<String>,
+    val skills: List<SkillResponse>,
     val availability: AvailabilityResponse?,
     val averageRating: Float
 )

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/ContractRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/ContractRepository.kt
@@ -57,6 +57,26 @@ class ContractRepository(private val apiService: ApiService) {
         }
     }
 
+    suspend fun getCompanyContracts(status: String? = null): ApiResult<List<ContractListResponse>> {
+        return try {
+            val response = apiService.getCompanyContracts(status)
+            when {
+                response.isSuccessful && response.body() != null ->
+                    ApiResult.Success(response.body()!!)
+                response.code() == 401 ->
+                    ApiResult.Error("No autorizado", 401)
+                response.code() == 403 ->
+                    ApiResult.Error("Acceso denegado", 403)
+                else ->
+                    ApiResult.Error("Error al cargar contratos (${response.code()})", response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado")
+        }
+    }
+
     suspend fun acceptContract(contractId: Int): ApiResult<ContractAcceptResponse> {
         return try {
             val response = apiService.acceptContract(contractId)

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
@@ -1,7 +1,10 @@
 package com.moviles.jobmatch.ui.screens.company
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,17 +15,22 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.AuthSession
 import com.moviles.jobmatch.data.Company
+import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
+import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.*
 import com.moviles.jobmatch.ui.screens.profile.DeleteAccountViewModel
-
+import com.moviles.jobmatch.ui.theme.DarkBlue
+import com.moviles.jobmatch.ui.utils.formatApplicationDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,8 +68,8 @@ fun CompanyProfileScreen(
             )
         }
     ) { paddingValues ->
-        when (uiState) {
-            is CompanyUiState.Loading -> {
+        when {
+            uiState.isLoading -> {
                 Box(
                     modifier = Modifier.fillMaxSize().padding(paddingValues),
                     contentAlignment = Alignment.Center
@@ -70,24 +78,14 @@ fun CompanyProfileScreen(
                 }
             }
 
-            is CompanyUiState.Success -> {
-                val company = (uiState as CompanyUiState.Success).company
-                CompanyProfileContent(
-                    company = company,
-                    isOwnProfile = isOwnProfile,
-                    onDeleteClick = { showDeleteDialog = true },
-                    modifier = Modifier.padding(paddingValues)
-                )
-            }
-
-            is CompanyUiState.Error -> {
+            uiState.errorMessage != null -> {
                 Box(
                     modifier = Modifier.fillMaxSize().padding(paddingValues),
                     contentAlignment = Alignment.Center
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(
-                            text = (uiState as CompanyUiState.Error).message,
+                            text = uiState.errorMessage!!,
                             color = MaterialTheme.colorScheme.error
                         )
                         Spacer(modifier = Modifier.height(8.dp))
@@ -96,6 +94,17 @@ fun CompanyProfileScreen(
                         }
                     }
                 }
+            }
+
+            uiState.company != null -> {
+                CompanyProfileContent(
+                    company = uiState.company!!,
+                    uiState = uiState,
+                    isOwnProfile = isOwnProfile,
+                    onDeleteClick = { showDeleteDialog = true },
+                    onExpandContract = { viewModel.loadContractDetail(it) },
+                    modifier = Modifier.padding(paddingValues)
+                )
             }
         }
     }
@@ -118,9 +127,11 @@ fun CompanyProfileScreen(
 @Composable
 fun CompanyProfileContent(
     company: Company,
+    uiState: CompanyProfileUiState,
     modifier: Modifier = Modifier,
     isOwnProfile: Boolean = false,
-    onDeleteClick: () -> Unit = {}
+    onDeleteClick: () -> Unit = {},
+    onExpandContract: (Int) -> Unit = {}
 ) {
     Column(
         modifier = modifier
@@ -173,6 +184,57 @@ fun CompanyProfileContent(
             )
         }
 
+        // --- Contratos Gestionados ---
+        if (isOwnProfile) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                SectionHeader(title = "Contratos Gestionados")
+                Spacer(modifier = Modifier.height(8.dp))
+                when {
+                    uiState.isLoadingContracts -> {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(64.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                color = DarkBlue,
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
+                    }
+                    uiState.contractsErrorMessage != null -> {
+                        Text(
+                            text = uiState.contractsErrorMessage!!,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                    uiState.contracts.isEmpty() -> {
+                        Text(
+                            text = "Sin contratos registrados",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color(0xFF9AA5B4)
+                        )
+                    }
+                    else -> {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            uiState.contracts.forEach { contract ->
+                                CompanyContractCard(
+                                    contract = contract,
+                                    detail = uiState.contractDetails[contract.idContract],
+                                    isLoadingDetail = contract.idContract in uiState.loadingContractIds,
+                                    detailError = uiState.contractDetailErrors[contract.idContract],
+                                    onExpand = { onExpandContract(contract.idContract) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
         if (isOwnProfile) {
             OutlinedButton(
                 onClick = onDeleteClick,
@@ -196,4 +258,202 @@ fun CompanyProfileContent(
     }
 }
 
+@Composable
+private fun CompanyContractCard(
+    contract: ContractListResponse,
+    detail: ContractDetailResponse?,
+    isLoadingDetail: Boolean,
+    detailError: String?,
+    onExpand: () -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
 
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "chevron"
+    )
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        expanded = !expanded
+                        if (expanded) onExpand()
+                    },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = contract.jobTitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color(0xFF1A1A1A)
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = contract.studentName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color(0xFF5A6A7A)
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        ContractStatusBadge(contract.status)
+                        Text(
+                            text = formatApplicationDate(contract.createdAt),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color(0xFF9AA5B4)
+                        )
+                    }
+                }
+                Icon(
+                    imageVector = Icons.Default.ExpandMore,
+                    contentDescription = if (expanded) "Contraer" else "Expandir",
+                    modifier = Modifier
+                        .size(24.dp)
+                        .rotate(chevronRotation),
+                    tint = Color(0xFF9AA5B4)
+                )
+            }
+
+            AnimatedVisibility(visible = expanded) {
+                Column {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(vertical = 12.dp),
+                        color = Color(0xFFF0F0F0)
+                    )
+                    when {
+                        isLoadingDetail -> {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(48.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator(
+                                    color = DarkBlue,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                            }
+                        }
+                        detailError != null -> {
+                            Text(
+                                text = detailError,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                        detail != null -> {
+                            val data = detail.parsedContractData
+                            ContractDetailSection(detail = detail)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContractDetailSection(detail: ContractDetailResponse) {
+    val data = detail.parsedContractData
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        if (!data?.workType.isNullOrEmpty()) {
+            ContractDetailRow(label = "Tipo de trabajo", value = data!!.workType!!)
+        }
+        if (!data?.studentEmail.isNullOrEmpty()) {
+            ContractDetailRow(label = "Correo del estudiante", value = data!!.studentEmail!!)
+        }
+        if (!data?.studentUniversity.isNullOrEmpty()) {
+            ContractDetailRow(label = "Universidad", value = data!!.studentUniversity!!)
+        }
+        if (!data?.studentCareer.isNullOrEmpty()) {
+            ContractDetailRow(label = "Carrera", value = data!!.studentCareer!!)
+        }
+        if (!data?.startDate.isNullOrEmpty()) {
+            ContractDetailRow(label = "Fecha de inicio", value = data!!.startDate!!)
+        }
+        if (!data?.endDate.isNullOrEmpty()) {
+            ContractDetailRow(label = "Fecha de fin", value = data!!.endDate!!)
+        }
+        if (!data?.compensation.isNullOrEmpty()) {
+            ContractDetailRow(label = "Compensación", value = data!!.compensation!!)
+        }
+        if (!data?.clauses.isNullOrEmpty()) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Cláusulas",
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xFF5A6A7A)
+            )
+            data!!.clauses!!.forEachIndexed { index, clause ->
+                Text(
+                    text = "• $clause",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFF5A6A7A),
+                    modifier = Modifier.padding(start = 4.dp)
+                )
+            }
+        }
+        detail.acceptedAt?.let {
+            Spacer(modifier = Modifier.height(2.dp))
+            ContractDetailRow(
+                label = "Aceptado el",
+                value = formatApplicationDate(it)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContractDetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = Color(0xFF9AA5B4),
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            color = Color(0xFF1A1A1A),
+            modifier = Modifier.weight(1.5f)
+        )
+    }
+}
+
+@Composable
+private fun ContractStatusBadge(status: String) {
+    val (bgColor, textColor, label) = when (status.lowercase()) {
+        "active" -> Triple(Color(0xFFE8F5E9), Color(0xFF2E7D32), "Activo")
+        "pending" -> Triple(Color(0xFFFFF8E1), Color(0xFFF57F17), "Pendiente")
+        else -> Triple(Color(0xFFF5F5F5), Color(0xFF757575), status.replaceFirstChar { it.uppercase() })
+    }
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = bgColor
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileViewModel.kt
@@ -2,33 +2,70 @@ package com.moviles.jobmatch.ui.screens.company
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.data.Company
+import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
+import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.repository.ApiResult
+import com.moviles.jobmatch.data.repository.AppContainer
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-sealed class CompanyUiState {
-    data object Loading : CompanyUiState()
-    data class Success(val company: Company) : CompanyUiState()
-    data class Error(val message: String) : CompanyUiState()
-}
+data class CompanyProfileUiState(
+    val isLoading: Boolean = false,
+    val company: Company? = null,
+    val contracts: List<ContractListResponse> = emptyList(),
+    val isLoadingContracts: Boolean = false,
+    val contractDetails: Map<Int, ContractDetailResponse> = emptyMap(),
+    val contractDetailErrors: Map<Int, String> = emptyMap(),
+    val loadingContractIds: Set<Int> = emptySet(),
+    val contractsErrorMessage: String? = null,
+    val errorMessage: String? = null
+)
 
 class CompanyProfileViewModel : ViewModel() {
-    private val _uiState = MutableStateFlow<CompanyUiState>(CompanyUiState.Loading)
-    val uiState: StateFlow<CompanyUiState> = _uiState.asStateFlow()
+    private val _uiState = MutableStateFlow(CompanyProfileUiState())
+    val uiState: StateFlow<CompanyProfileUiState> = _uiState.asStateFlow()
 
     fun loadCompanyProfile(companyId: String) {
         viewModelScope.launch {
-            _uiState.value = CompanyUiState.Loading
-            when (val result = AppContainer.companyRepository.getCompanyById(companyId)) {
-                is ApiResult.Success -> {
-                    _uiState.value = CompanyUiState.Success(result.data)
+            _uiState.update { it.copy(isLoading = true, isLoadingContracts = true, errorMessage = null) }
+
+            val profileDeferred = async { AppContainer.companyRepository.getCompanyById(companyId) }
+            val contractsDeferred = async { AppContainer.contractRepository.getCompanyContracts() }
+
+            when (val result = profileDeferred.await()) {
+                is ApiResult.Success -> _uiState.update { it.copy(isLoading = false, company = result.data) }
+                is ApiResult.Error -> _uiState.update { it.copy(isLoading = false, errorMessage = result.message) }
+            }
+
+            when (val result = contractsDeferred.await()) {
+                is ApiResult.Success -> _uiState.update { it.copy(isLoadingContracts = false, contracts = result.data) }
+                is ApiResult.Error -> _uiState.update { it.copy(isLoadingContracts = false, contractsErrorMessage = result.message) }
+            }
+        }
+    }
+
+    fun loadContractDetail(contractId: Int) {
+        if (_uiState.value.contractDetails.containsKey(contractId) ||
+            _uiState.value.loadingContractIds.contains(contractId)) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(loadingContractIds = it.loadingContractIds + contractId) }
+            when (val result = AppContainer.contractRepository.getContractById(contractId)) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(
+                        contractDetails = it.contractDetails + (contractId to result.data),
+                        loadingContractIds = it.loadingContractIds - contractId
+                    )
                 }
-                is ApiResult.Error -> {
-                    _uiState.value = CompanyUiState.Error(result.message)
+                is ApiResult.Error -> _uiState.update {
+                    it.copy(
+                        contractDetailErrors = it.contractDetailErrors + (contractId to result.message),
+                        loadingContractIds = it.loadingContractIds - contractId
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -229,7 +229,7 @@ fun StudentProfileScreen(
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
-                                skills.forEach { skill -> SkillChip(skill) }
+                                skills.forEach { skill -> SkillChip(skill.skillName) }
                             }
                         } else {
                             Text(

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentPublicProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentPublicProfileScreen.kt
@@ -208,7 +208,7 @@ private fun ProfileContent(
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         student.skills.forEach { skill ->
-                            SkillChip(text = skill)
+                            SkillChip(text = skill.skillName)
                         }
                     }
                 }


### PR DESCRIPTION
# Pull Request

## Description

Adds a "Contratos Gestionados" section to the Company Profile screen (issue #71). Companies can now see all contracts they have generated, each displayed as an expandable card showing the student name, job title, status badge, and creation date. Tapping a card loads and reveals the full contract detail — work type, student info, dates, compensation, and clauses — via the existing GET /contracts/{contractId} endpoint. Contract detail is loaded lazily on first expand and cached in the ViewModel so subsequent toggles don't trigger extra network calls.

Also fixes two pre-existing bugs found during integration: the student profile was crashing with `IllegalStateException: Expected a string but was BEGIN_OBJECT at $.skills[0]` because the Kotlin model had `List<String>` while the backend returns `List<{skillId, skillName}>` since PR #77; and the company contracts were being fetched from the wrong route (`contracts/company` instead of `contracts`).

---

## Related Issue

Closes #71

---

## Changes Included

### Backend Changes

* [ ] Added new endpoint(s)
* [ ] Added/updated DTOs
* [ ] Added/updated services
* [ ] Added/updated repositories
* [ ] Added/updated database migrations
* [ ] Added validations
* [ ] Added exception handling
* [ ] Other:

### Frontend / Mobile Changes

* [ ] Added new screen(s)
* [x] Added ViewModel(s): refactored `CompanyProfileViewModel` from sealed `CompanyUiState` to `data class CompanyProfileUiState`; added parallel loading of company profile + contracts with `async`; added `loadContractDetail()` with per-contract loading/error tracking
* [ ] Added navigation
* [x] Added API integration: `GET /contracts` (company role) and `GET /contracts/{contractId}` wired through `ContractRepository.getCompanyContracts()` and existing `getContractById()`
* [x] Added loading/error states: independent loading spinners for profile and contracts sections; inline error messages per section
* [ ] Added validation
* [x] Updated UI components: added `CompanyContractCard` (expand/collapse with animation), `ContractStatusBadge` (color-coded: active=green, pending=yellow), `ContractDetailSection`, `ContractDetailRow` as private composables in `CompanyProfileScreen.kt`
* [x] Other: fixed `SkillResponse` type mismatch in `StudentModels.kt` and updated `StudentProfileScreen` and `StudentPublicProfileScreen` to use `skill.skillName`

---

## Architecture

CompanyProfileScreen
→ CompanyProfileViewModel (data class UiState, same pattern as StudentProfileViewModel)
→ CompanyRepository.getCompanyById()       — company profile data
→ ContractRepository.getCompanyContracts() — GET /contracts (Company role)
→ ContractRepository.getContractById()     — GET /contracts/{contractId} (lazy on expand)

Company profile and contracts load in parallel with `async`. Contract detail loads lazily on first expand and is cached in `contractDetails

---

## API / Database Changes

No new endpoints. Uses:
- `GET /contracts` — existing endpoint, restricted to `[Authorize(Roles = "Company")]`, returns `List<ContractListResponse>`
- `GET /contracts/{contractId}` — existing endpoint, ownership check server-side

No database or migration changes.

---

## Testing Performed

* [x] Feature tested manually
* [x] Navigation tested
* [x] Error handling tested
* [x] Validation tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

- Company profile loads correctly with the new "Contratos Gestionados" section visible only on own profile
- Empty state ("Sin contratos registrados") renders when the company has no contracts
- Tapping a contract card expands it with an animation and triggers `GET /contracts/{contractId}`; spinner shows during load, detail renders on success
- Tapping again collapses the card; re-expanding uses the cached detail without a new network call
- Error state (e.g. server down) shows inline error message per contract without crashing the screen
- Student profile no longer crashes — skills render correctly after `SkillResponse` type fix
- Student public profile (visible to companies from applicant detail) also renders skills correctly

---

## Evidence

<img width="720" height="1280" alt="image" src="https://github.com/user-attachments/assets/8ab8b512-3f07-4f95-bd4d-1cc77b6a6237" />

<img width="720" height="1280" alt="image" src="https://github.com/user-attachments/assets/2a11fbfe-195a-44cf-9326-52a09299a598" />



---

## Notes

The section is only rendered when `isOwnProfile == true` (companyId matches the authenticated user's id from `AuthSession`), so companies viewing another company's public profile do not see the contracts section. The view-only design (no accept button) reflects the company's role — contract acceptance is handled by the student side.