### PR TITLE
Feature/view payment history

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -24,6 +24,7 @@ import com.moviles.jobmatch.data.remote.model.ContractAcceptResponse
 import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.remote.model.DeleteUserRequest
+import com.moviles.jobmatch.data.remote.model.PaymentResponse
 import com.moviles.jobmatch.data.remote.model.UpdateAvailabilityRequest
 import retrofit2.Response
 import retrofit2.http.Body
@@ -107,6 +108,12 @@ interface ApiService {
 
     @PUT("contracts/{contractId}/accept")
     suspend fun acceptContract(@Path("contractId") contractId: Int): Response<ContractAcceptResponse>
+
+    @GET("payments")
+    suspend fun getPaymentHistory(
+        @Query("startDate") startDate: String? = null,
+        @Query("endDate") endDate: String? = null
+    ): Response<List<PaymentResponse>>
 
     @HTTP(method = "DELETE", path = "users/{userId}", hasBody = true)
     suspend fun deleteUser(

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/PaymentModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/PaymentModels.kt
@@ -1,0 +1,12 @@
+package com.moviles.jobmatch.data.remote.model
+
+data class PaymentResponse(
+    val idPayment: Int,
+    val idContract: Int,
+    val amount: Double,
+    val paymentMethod: String,
+    val date: String,
+    val type: String,
+    val receiptUrl: String? = null,
+    val concept: String? = null
+)

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/AppContainer.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/AppContainer.kt
@@ -30,4 +30,8 @@ object AppContainer {
     val contractRepository: ContractRepository by lazy {
         ContractRepository(RetrofitClient.apiService)
     }
+
+    val paymentRepository: PaymentRepository by lazy {
+        PaymentRepository(RetrofitClient.apiService)
+    }
 }

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/PaymentRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/PaymentRepository.kt
@@ -1,0 +1,36 @@
+package com.moviles.jobmatch.data.repository
+
+import com.moviles.jobmatch.data.remote.ApiService
+import com.moviles.jobmatch.data.remote.model.PaymentResponse
+import java.io.IOException
+
+class PaymentRepository(private val apiService: ApiService) {
+
+    suspend fun getPaymentHistory(
+        startDate: String? = null,
+        endDate: String? = null
+    ): ApiResult<List<PaymentResponse>> {
+        return try {
+            val response = apiService.getPaymentHistory(startDate, endDate)
+            if (response.isSuccessful && response.body() != null) {
+                ApiResult.Success(response.body()!!)
+            } else {
+                val message = parseErrorBody(response) ?: "Error al cargar historial (${response.code()})"
+                ApiResult.Error(message, response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado")
+        }
+    }
+
+    private fun parseErrorBody(response: retrofit2.Response<*>): String? {
+        return try {
+            val body = response.errorBody()?.string() ?: return null
+            org.json.JSONObject(body).optString("message").takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppDestinations.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppDestinations.kt
@@ -36,6 +36,7 @@ object AppDestinations {
         "$STUDENT_PUBLIC_PROFILE/${Uri.encode(studentId)}"
 
     const val AVAILABILITY = "availability"
+    const val PAYMENT_HISTORY = "payment_history"
 
     fun companyProfileRoute(companyId: String): String {
         return "$COMPANY_PROFILE/${Uri.encode(companyId)}"

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
@@ -36,6 +36,7 @@ import com.moviles.jobmatch.ui.screens.register.RegisterScreen
 import com.moviles.jobmatch.ui.screens.splash.SplashScreen
 import com.moviles.jobmatch.ui.screens.profile.StudentProfileScreen
 import com.moviles.jobmatch.ui.screens.availability.AvailabilityScreen
+import com.moviles.jobmatch.ui.screens.payment.PaymentHistoryScreen
 
 @Composable
 fun AppNavHost(modifier: Modifier = Modifier) {
@@ -51,6 +52,7 @@ fun AppNavHost(modifier: Modifier = Modifier) {
     val showBottomBar = currentRoute != AppDestinations.SPLASH &&
             currentRoute != AppDestinations.LOGIN &&
             currentRoute != AppDestinations.REGISTER &&
+            currentRoute != AppDestinations.PAYMENT_HISTORY &&
             currentRoute?.startsWith(AppDestinations.JOB_DETAIL) != true &&
             currentRoute?.startsWith(AppDestinations.EDIT_JOB) != true &&
             currentRoute?.startsWith(AppDestinations.APPLICATIONS) != true &&
@@ -192,6 +194,7 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                 CompanyProfileScreen(
                     companyId = id,
                     onBackPressed = { navController.popBackStack() },
+                    onPaymentHistory = { navController.navigate(AppDestinations.PAYMENT_HISTORY) },
                     onAccountDeleted = {
                         navController.navigate(AppDestinations.LOGIN) {
                             popUpTo(0) { inclusive = true }
@@ -319,6 +322,9 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                     onEditAvailability = {
                         navController.navigate(AppDestinations.AVAILABILITY)
                     },
+                    onPaymentHistory = {
+                        navController.navigate(AppDestinations.PAYMENT_HISTORY)
+                    },
                     onAccountDeleted = {
                         navController.navigate(AppDestinations.LOGIN) {
                             popUpTo(0) { inclusive = true }
@@ -332,6 +338,9 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                     onEditAvailability = {
                         navController.navigate(AppDestinations.AVAILABILITY)
                     },
+                    onPaymentHistory = {
+                        navController.navigate(AppDestinations.PAYMENT_HISTORY)
+                    },
                     onAccountDeleted = {
                         navController.navigate(AppDestinations.LOGIN) {
                             popUpTo(0) { inclusive = true }
@@ -344,6 +353,12 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                 AvailabilityScreen(
                     onBackPressed = { navController.popBackStack() },
                     onSaved = { navController.popBackStack() }
+                )
+            }
+
+            composable(route = AppDestinations.PAYMENT_HISTORY) {
+                PaymentHistoryScreen(
+                    onBackPressed = { navController.popBackStack() }
                 )
             }
         }

--- a/app/src/main/java/com/moviles/jobmatch/ui/components/DateRangePickerDialog.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/components/DateRangePickerDialog.kt
@@ -1,0 +1,66 @@
+package com.moviles.jobmatch.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DateRangePickerDialog(
+    initialStart: String?,
+    initialEnd: String?,
+    onApply: (startDate: String?, endDate: String?) -> Unit,
+    onClear: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var startDate by remember { mutableStateOf(initialStart ?: "") }
+    var endDate by remember { mutableStateOf(initialEnd ?: "") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Filtrar por fecha", fontWeight = FontWeight.SemiBold) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                DatePickerField(
+                    label = "Desde",
+                    value = startDate,
+                    onDateSelected = { startDate = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                DatePickerField(
+                    label = "Hasta",
+                    value = endDate,
+                    onDateSelected = { endDate = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onApply(
+                    startDate.ifBlank { null },
+                    endDate.ifBlank { null }
+                )
+            }) { Text("Aplicar") }
+        },
+        dismissButton = {
+            Row {
+                TextButton(onClick = onClear) { Text("Limpiar") }
+                TextButton(onClick = onDismiss) { Text("Cancelar") }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/components/PaymentCard.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/components/PaymentCard.kt
@@ -1,0 +1,106 @@
+package com.moviles.jobmatch.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CallMade
+import androidx.compose.material.icons.filled.CallReceived
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.moviles.jobmatch.data.remote.model.PaymentResponse
+import com.moviles.jobmatch.ui.utils.formatApplicationDate
+import java.text.NumberFormat
+import java.util.Locale
+
+@Composable
+fun PaymentCard(
+    payment: PaymentResponse,
+    modifier: Modifier = Modifier
+) {
+    val isReceived = payment.type == "received"
+    val amountColor = if (isReceived) Color(0xFF2E7D32) else Color(0xFFC62828)
+    val amountPrefix = if (isReceived) "+" else "-"
+    val icon = if (isReceived) Icons.Default.CallReceived else Icons.Default.CallMade
+    val iconBg = if (isReceived) Color(0xFFE8F5E9) else Color(0xFFFFEBEE)
+    val iconTint = if (isReceived) Color(0xFF2E7D32) else Color(0xFFC62828)
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(iconBg),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = iconTint,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = payment.concept ?: "Pago de trabajo",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF1A2332)
+                )
+                Text(
+                    text = "REF: JM-${String.format("%05d", payment.idContract)} · ${formatPaymentMethod(payment.paymentMethod)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFF9AA5B4)
+                )
+            }
+
+            Spacer(Modifier.width(8.dp))
+
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "$amountPrefix${formatColones(payment.amount)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = amountColor
+                )
+                Text(
+                    text = formatApplicationDate(payment.date),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color(0xFF9AA5B4)
+                )
+            }
+        }
+    }
+}
+
+fun formatColones(amount: Double): String {
+    val format = NumberFormat.getNumberInstance(Locale("es", "CR"))
+    format.maximumFractionDigits = 0
+    return "₡${format.format(amount)}"
+}
+
+fun formatPaymentMethod(method: String): String = when (method.lowercase()) {
+    "transfer" -> "Transferencia"
+    "cash" -> "Efectivo"
+    "sinpe" -> "SINPE Móvil"
+    else -> method.replaceFirstChar { it.uppercase() }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
@@ -38,6 +38,7 @@ fun CompanyProfileScreen(
     companyId: String,
     onBackPressed: () -> Unit = {},
     onSettingsPressed: () -> Unit = {},
+    onPaymentHistory: () -> Unit = {},
     onAccountDeleted: () -> Unit = {},
     viewModel: CompanyProfileViewModel = viewModel()
 ) {
@@ -101,6 +102,7 @@ fun CompanyProfileScreen(
                     company = uiState.company!!,
                     uiState = uiState,
                     isOwnProfile = isOwnProfile,
+                    onPaymentHistory = onPaymentHistory,
                     onDeleteClick = { showDeleteDialog = true },
                     onExpandContract = { viewModel.loadContractDetail(it) },
                     modifier = Modifier.padding(paddingValues)
@@ -130,6 +132,7 @@ fun CompanyProfileContent(
     uiState: CompanyProfileUiState,
     modifier: Modifier = Modifier,
     isOwnProfile: Boolean = false,
+    onPaymentHistory: () -> Unit = {},
     onDeleteClick: () -> Unit = {},
     onExpandContract: (Int) -> Unit = {}
 ) {
@@ -236,6 +239,31 @@ fun CompanyProfileContent(
         }
 
         if (isOwnProfile) {
+            OutlinedButton(
+                onClick = onPaymentHistory,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .height(48.dp),
+                shape = RoundedCornerShape(12.dp),
+                border = BorderStroke(1.dp, DarkBlue),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = DarkBlue)
+            ) {
+                Icon(
+                    Icons.Default.Receipt,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "Historial de Pagos",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
             OutlinedButton(
                 onClick = onDeleteClick,
                 modifier = Modifier

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryScreen.kt
@@ -22,13 +22,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.AuthSession
 import com.moviles.jobmatch.data.repository.AppContainer
-import com.moviles.jobmatch.ui.components.DatePickerField
+import com.moviles.jobmatch.ui.components.DateRangePickerDialog
 import com.moviles.jobmatch.ui.components.PaymentCard
 import com.moviles.jobmatch.ui.components.SectionHeader
 import com.moviles.jobmatch.ui.components.formatColones
-import com.moviles.jobmatch.ui.components.formatPaymentMethod
 import com.moviles.jobmatch.ui.theme.DarkBlue
-import com.moviles.jobmatch.ui.utils.formatApplicationDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -147,7 +145,7 @@ fun PaymentHistoryScreen(
     }
 
     if (showDateFilter) {
-        DateFilterDialog(
+        DateRangePickerDialog(
             initialStart = state.startDate,
             initialEnd = state.endDate,
             onApply = { start, end ->
@@ -251,53 +249,6 @@ private fun FilterRow(
 }
 
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun DateFilterDialog(
-    initialStart: String?,
-    initialEnd: String?,
-    onApply: (String?, String?) -> Unit,
-    onClear: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    var startDate by remember { mutableStateOf(initialStart ?: "") }
-    var endDate by remember { mutableStateOf(initialEnd ?: "") }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Filtrar por fecha", fontWeight = FontWeight.SemiBold) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                DatePickerField(
-                    label = "Desde",
-                    value = startDate,
-                    onDateSelected = { startDate = it },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                DatePickerField(
-                    label = "Hasta",
-                    value = endDate,
-                    onDateSelected = { endDate = it },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                onApply(
-                    startDate.ifBlank { null },
-                    endDate.ifBlank { null }
-                )
-            }) { Text("Aplicar") }
-        },
-        dismissButton = {
-            Row {
-                TextButton(onClick = onClear) { Text("Limpiar") }
-                TextButton(onClick = onDismiss) { Text("Cancelar") }
-            }
-        }
-    )
-}
 
 // Groups payments by date label: "HOY", "AYER", or "MES AÑO"
 private fun List<PaymentResponse>.groupByDate(): LinkedHashMap<String, List<PaymentResponse>> {

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryScreen.kt
@@ -4,13 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.FilterList
-import androidx.compose.material.icons.filled.CallReceived
-import androidx.compose.material.icons.filled.CallMade
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -24,14 +21,14 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.AuthSession
-import com.moviles.jobmatch.data.remote.model.PaymentResponse
 import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.DatePickerField
+import com.moviles.jobmatch.ui.components.PaymentCard
 import com.moviles.jobmatch.ui.components.SectionHeader
+import com.moviles.jobmatch.ui.components.formatColones
+import com.moviles.jobmatch.ui.components.formatPaymentMethod
 import com.moviles.jobmatch.ui.theme.DarkBlue
 import com.moviles.jobmatch.ui.utils.formatApplicationDate
-import java.text.NumberFormat
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -137,7 +134,7 @@ fun PaymentHistoryScreen(
                                 )
                             }
                             items(payments, key = { it.idPayment }) { payment ->
-                                PaymentItem(
+                                PaymentCard(
                                     payment = payment,
                                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
                                 )
@@ -253,74 +250,6 @@ private fun FilterRow(
     }
 }
 
-@Composable
-private fun PaymentItem(payment: PaymentResponse, modifier: Modifier = Modifier) {
-    val isReceived = payment.type == "received"
-    val amountColor = if (isReceived) Color(0xFF2E7D32) else Color(0xFFC62828)
-    val amountPrefix = if (isReceived) "+" else "-"
-    val icon = if (isReceived) Icons.Default.CallReceived else Icons.Default.CallMade
-    val iconBg = if (isReceived) Color(0xFFE8F5E9) else Color(0xFFFFEBEE)
-    val iconTint = if (isReceived) Color(0xFF2E7D32) else Color(0xFFC62828)
-
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .clip(CircleShape)
-                    .background(iconBg),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = iconTint,
-                    modifier = Modifier.size(20.dp)
-                )
-            }
-
-            Spacer(Modifier.width(12.dp))
-
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = payment.concept ?: "Pago de trabajo",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = Color(0xFF1A2332)
-                )
-                Text(
-                    text = "REF: JM-${String.format("%05d", payment.idContract)} · ${formatPaymentMethod(payment.paymentMethod)}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFF9AA5B4)
-                )
-            }
-
-            Spacer(Modifier.width(8.dp))
-
-            Column(horizontalAlignment = Alignment.End) {
-                Text(
-                    text = "$amountPrefix${formatColones(payment.amount)}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = amountColor
-                )
-                Text(
-                    text = formatApplicationDate(payment.date),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = Color(0xFF9AA5B4)
-                )
-            }
-        }
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -396,15 +325,3 @@ private fun List<PaymentResponse>.groupByDate(): LinkedHashMap<String, List<Paym
     return result
 }
 
-private fun formatColones(amount: Double): String {
-    val format = NumberFormat.getNumberInstance(Locale("es", "CR"))
-    format.maximumFractionDigits = 0
-    return "₡${format.format(amount)}"
-}
-
-private fun formatPaymentMethod(method: String): String = when (method.lowercase()) {
-    "transfer" -> "Transferencia"
-    "cash" -> "Efectivo"
-    "sinpe" -> "SINPE Móvil"
-    else -> method.replaceFirstChar { it.uppercase() }
-}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryScreen.kt
@@ -21,7 +21,9 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.moviles.jobmatch.data.AuthSession
+import com.moviles.jobmatch.data.remote.model.PaymentResponse
 import com.moviles.jobmatch.data.repository.AppContainer
+import java.util.Locale
 import com.moviles.jobmatch.ui.components.DateRangePickerDialog
 import com.moviles.jobmatch.ui.components.PaymentCard
 import com.moviles.jobmatch.ui.components.SectionHeader

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryScreen.kt
@@ -1,0 +1,410 @@
+package com.moviles.jobmatch.ui.screens.payment
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.CallReceived
+import androidx.compose.material.icons.filled.CallMade
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.moviles.jobmatch.data.AuthSession
+import com.moviles.jobmatch.data.remote.model.PaymentResponse
+import com.moviles.jobmatch.data.repository.AppContainer
+import com.moviles.jobmatch.ui.components.DatePickerField
+import com.moviles.jobmatch.ui.components.SectionHeader
+import com.moviles.jobmatch.ui.theme.DarkBlue
+import com.moviles.jobmatch.ui.utils.formatApplicationDate
+import java.text.NumberFormat
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PaymentHistoryScreen(
+    onBackPressed: () -> Unit = {}
+) {
+    val viewModel: PaymentHistoryViewModel = viewModel(
+        factory = PaymentHistoryViewModel.Factory(AppContainer.paymentRepository)
+    )
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var showDateFilter by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("Historial de Pagos", fontWeight = FontWeight.SemiBold, fontSize = 17.sp)
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackPressed) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.White)
+            )
+        },
+        containerColor = Color(0xFFF5F7FA)
+    ) { padding ->
+        when {
+            state.isLoading -> {
+                Box(
+                    Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center
+                ) { CircularProgressIndicator(color = DarkBlue) }
+            }
+
+            state.errorMessage != null -> {
+                Box(
+                    Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.padding(24.dp)
+                    ) {
+                        Text(
+                            state.errorMessage!!,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Spacer(Modifier.height(16.dp))
+                        Button(
+                            onClick = { viewModel.load() },
+                            colors = ButtonDefaults.buttonColors(containerColor = DarkBlue)
+                        ) { Text("Reintentar") }
+                    }
+                }
+            }
+
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentPadding = PaddingValues(bottom = 24.dp)
+                ) {
+                    item {
+                        BalanceCard(
+                            state = state,
+                            modifier = Modifier.padding(16.dp)
+                        )
+                    }
+
+                    item {
+                        FilterRow(
+                            activeFilter = state.filter,
+                            hasDateFilter = state.startDate != null || state.endDate != null,
+                            onFilterChange = viewModel::setFilter,
+                            onDateFilterClick = { showDateFilter = true },
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                        Spacer(Modifier.height(8.dp))
+                    }
+
+                    if (state.filtered.isEmpty()) {
+                        item {
+                            Box(
+                                modifier = Modifier.fillMaxWidth().padding(32.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    "Sin pagos registrados",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color(0xFF9AA5B4)
+                                )
+                            }
+                        }
+                    } else {
+                        val grouped = state.filtered.groupByDate()
+                        grouped.forEach { (label, payments) ->
+                            item {
+                                SectionHeader(
+                                    title = label,
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)
+                                )
+                            }
+                            items(payments, key = { it.idPayment }) { payment ->
+                                PaymentItem(
+                                    payment = payment,
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDateFilter) {
+        DateFilterDialog(
+            initialStart = state.startDate,
+            initialEnd = state.endDate,
+            onApply = { start, end ->
+                viewModel.applyDateRange(start, end)
+                showDateFilter = false
+            },
+            onClear = {
+                viewModel.clearDateRange()
+                showDateFilter = false
+            },
+            onDismiss = { showDateFilter = false }
+        )
+    }
+}
+
+@Composable
+private fun BalanceCard(state: PaymentHistoryUiState, modifier: Modifier = Modifier) {
+    val isCompany = AuthSession.isCompany
+    val mainAmount = if (isCompany) state.totalMade else state.totalReceived
+    val label = if (isCompany) "TOTAL PAGADO" else "TOTAL RECIBIDO"
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(Brush.horizontalGradient(listOf(DarkBlue, Color(0xFF1976D2))))
+            .padding(20.dp)
+    ) {
+        Column {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = Color.White.copy(alpha = 0.8f),
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 1.sp
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = formatColones(mainAmount),
+                style = MaterialTheme.typography.headlineMedium,
+                color = Color.White,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(Modifier.height(8.dp))
+            if (!isCompany && state.totalMade > 0) {
+                Surface(
+                    shape = RoundedCornerShape(20.dp),
+                    color = Color.White.copy(alpha = 0.2f)
+                ) {
+                    Text(
+                        text = "Pagado: ${formatColones(state.totalMade)}",
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterRow(
+    activeFilter: PaymentFilter,
+    hasDateFilter: Boolean,
+    onFilterChange: (PaymentFilter) -> Unit,
+    onDateFilterClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        listOf(
+            PaymentFilter.ALL to "Todos",
+            PaymentFilter.RECEIVED to "Ingresos",
+            PaymentFilter.MADE to "Egresos"
+        ).forEach { (filter, label) ->
+            FilterChip(
+                selected = activeFilter == filter,
+                onClick = { onFilterChange(filter) },
+                label = { Text(label, style = MaterialTheme.typography.bodySmall) },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = DarkBlue,
+                    selectedLabelColor = Color.White
+                )
+            )
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        IconButton(onClick = onDateFilterClick, modifier = Modifier.size(36.dp)) {
+            Icon(
+                Icons.Default.FilterList,
+                contentDescription = "Filtrar por fecha",
+                tint = if (hasDateFilter) DarkBlue else Color(0xFF9AA5B4)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PaymentItem(payment: PaymentResponse, modifier: Modifier = Modifier) {
+    val isReceived = payment.type == "received"
+    val amountColor = if (isReceived) Color(0xFF2E7D32) else Color(0xFFC62828)
+    val amountPrefix = if (isReceived) "+" else "-"
+    val icon = if (isReceived) Icons.Default.CallReceived else Icons.Default.CallMade
+    val iconBg = if (isReceived) Color(0xFFE8F5E9) else Color(0xFFFFEBEE)
+    val iconTint = if (isReceived) Color(0xFF2E7D32) else Color(0xFFC62828)
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(iconBg),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = iconTint,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = payment.concept ?: "Pago de trabajo",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF1A2332)
+                )
+                Text(
+                    text = "REF: JM-${String.format("%05d", payment.idContract)} · ${formatPaymentMethod(payment.paymentMethod)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFF9AA5B4)
+                )
+            }
+
+            Spacer(Modifier.width(8.dp))
+
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "$amountPrefix${formatColones(payment.amount)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = amountColor
+                )
+                Text(
+                    text = formatApplicationDate(payment.date),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color(0xFF9AA5B4)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DateFilterDialog(
+    initialStart: String?,
+    initialEnd: String?,
+    onApply: (String?, String?) -> Unit,
+    onClear: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var startDate by remember { mutableStateOf(initialStart ?: "") }
+    var endDate by remember { mutableStateOf(initialEnd ?: "") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Filtrar por fecha", fontWeight = FontWeight.SemiBold) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                DatePickerField(
+                    label = "Desde",
+                    value = startDate,
+                    onDateSelected = { startDate = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                DatePickerField(
+                    label = "Hasta",
+                    value = endDate,
+                    onDateSelected = { endDate = it },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onApply(
+                    startDate.ifBlank { null },
+                    endDate.ifBlank { null }
+                )
+            }) { Text("Aplicar") }
+        },
+        dismissButton = {
+            Row {
+                TextButton(onClick = onClear) { Text("Limpiar") }
+                TextButton(onClick = onDismiss) { Text("Cancelar") }
+            }
+        }
+    )
+}
+
+// Groups payments by date label: "HOY", "AYER", or "MES AÑO"
+private fun List<PaymentResponse>.groupByDate(): LinkedHashMap<String, List<PaymentResponse>> {
+    val result = LinkedHashMap<String, List<PaymentResponse>>()
+    val today = java.util.Calendar.getInstance()
+    val yesterday = java.util.Calendar.getInstance().apply { add(java.util.Calendar.DAY_OF_YEAR, -1) }
+
+    forEach { payment ->
+        val label = try {
+            val sdf = java.text.SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val date = sdf.parse(payment.date) ?: return@forEach
+            val cal = java.util.Calendar.getInstance().apply { time = date }
+            when {
+                cal.get(java.util.Calendar.YEAR) == today.get(java.util.Calendar.YEAR) &&
+                        cal.get(java.util.Calendar.DAY_OF_YEAR) == today.get(java.util.Calendar.DAY_OF_YEAR) -> "HOY"
+                cal.get(java.util.Calendar.YEAR) == yesterday.get(java.util.Calendar.YEAR) &&
+                        cal.get(java.util.Calendar.DAY_OF_YEAR) == yesterday.get(java.util.Calendar.DAY_OF_YEAR) -> "AYER"
+                else -> java.text.SimpleDateFormat("MMMM yyyy", Locale("es")).format(date)
+                    .replaceFirstChar { it.uppercase() }
+            }
+        } catch (e: Exception) { payment.date }
+
+        result[label] = (result[label] ?: emptyList()) + payment
+    }
+    return result
+}
+
+private fun formatColones(amount: Double): String {
+    val format = NumberFormat.getNumberInstance(Locale("es", "CR"))
+    format.maximumFractionDigits = 0
+    return "₡${format.format(amount)}"
+}
+
+private fun formatPaymentMethod(method: String): String = when (method.lowercase()) {
+    "transfer" -> "Transferencia"
+    "cash" -> "Efectivo"
+    "sinpe" -> "SINPE Móvil"
+    else -> method.replaceFirstChar { it.uppercase() }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/payment/PaymentHistoryViewModel.kt
@@ -1,0 +1,77 @@
+package com.moviles.jobmatch.ui.screens.payment
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.moviles.jobmatch.data.remote.model.PaymentResponse
+import com.moviles.jobmatch.data.repository.ApiResult
+import com.moviles.jobmatch.data.repository.PaymentRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+enum class PaymentFilter { ALL, RECEIVED, MADE }
+
+data class PaymentHistoryUiState(
+    val isLoading: Boolean = false,
+    val payments: List<PaymentResponse> = emptyList(),
+    val filter: PaymentFilter = PaymentFilter.ALL,
+    val startDate: String? = null,
+    val endDate: String? = null,
+    val errorMessage: String? = null
+) {
+    val filtered: List<PaymentResponse> get() = when (filter) {
+        PaymentFilter.ALL -> payments
+        PaymentFilter.RECEIVED -> payments.filter { it.type == "received" }
+        PaymentFilter.MADE -> payments.filter { it.type == "made" }
+    }
+
+    val totalReceived: Double get() = payments.filter { it.type == "received" }.sumOf { it.amount }
+    val totalMade: Double get() = payments.filter { it.type == "made" }.sumOf { it.amount }
+}
+
+class PaymentHistoryViewModel(
+    private val repository: PaymentRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PaymentHistoryUiState())
+    val uiState: StateFlow<PaymentHistoryUiState> = _uiState.asStateFlow()
+
+    init { load() }
+
+    fun load() {
+        val state = _uiState.value
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            when (val result = repository.getPaymentHistory(state.startDate, state.endDate)) {
+                is ApiResult.Success ->
+                    _uiState.update { it.copy(isLoading = false, payments = result.data) }
+                is ApiResult.Error ->
+                    _uiState.update { it.copy(isLoading = false, errorMessage = result.message) }
+            }
+        }
+    }
+
+    fun setFilter(filter: PaymentFilter) {
+        _uiState.update { it.copy(filter = filter) }
+    }
+
+    fun applyDateRange(startDate: String?, endDate: String?) {
+        _uiState.update { it.copy(startDate = startDate, endDate = endDate) }
+        load()
+    }
+
+    fun clearDateRange() {
+        _uiState.update { it.copy(startDate = null, endDate = null) }
+        load()
+    }
+
+    class Factory(private val repository: PaymentRepository) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return PaymentHistoryViewModel(repository) as T
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -74,8 +74,9 @@ import com.moviles.jobmatch.ui.utils.formatApplicationDate
 @Composable
 fun StudentProfileScreen(
     onSettingsClick: () -> Unit = {},
-    onEditAvailability: () -> Unit = {},   // from this PR
-    onAccountDeleted: () -> Unit = {}      // from PR #66
+    onEditAvailability: () -> Unit = {},
+    onPaymentHistory: () -> Unit = {},
+    onAccountDeleted: () -> Unit = {}
 ) {
     val viewModel: StudentProfileViewModel = viewModel(
         factory = StudentProfileViewModelFactory(AppContainer.studentRepository, AppContainer.contractRepository)
@@ -275,7 +276,7 @@ fun StudentProfileScreen(
                         SectionHeader(
                             title = "Experiencia Reciente",
                             actionText = "Historial",
-                            onActionClick = {}
+                            onActionClick = onPaymentHistory
                         )
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(


### PR DESCRIPTION
 # Pull Request

  ## Description

  Implements the payment history screen (issue #) for the JobMatch mobile app. Authenticated users can now view all payments associated with
  their contracts directly from their profile.

  Students see payments they have received (income), companies see payments they have made (expenses). The screen shows each payment grouped by
  date with the concept, reference, payment method, amount and color-coded direction indicator. A filter row lets the user narrow the list to
  ingresos or egresos only, and a date range picker dialog lets them filter by a custom start/end date, which is sent as query parameters to the
  backend.

  ---

  ## Related Issue

  Closes #20 View Payment history

  ---

  ## Changes Included

  ### Frontend / Mobile Changes

  * [x] Added new screen(s) — `PaymentHistoryScreen.kt`
  * [x] Added ViewModel(s) — `PaymentHistoryViewModel.kt` with `PaymentFilter` enum and `PaymentHistoryUiState`
  * [x] Added navigation — `PAYMENT_HISTORY` route in `AppDestinations` and `AppNavHost`; bottom bar hidden on this screen
  * [x] Added API integration — `GET /payments` with optional `startDate` / `endDate` query params via `PaymentRepository`
  * [x] Added loading/error states — full-screen spinner on load, error message with retry button
  * [ ] Added validation
  * [x] Updated UI components — added `PaymentCard`, `DateRangePickerDialog` to `ui/components`; `StudentProfileScreen` and
  `CompanyProfileScreen` now have navigation entry points
  * [ ] Other:

  ---

  ## Architecture

  UI (PaymentHistoryScreen)
    → ViewModel (PaymentHistoryViewModel)
      → Repository (PaymentRepository)
        → API (ApiService — GET /payments?startDate=&endDate=)

  Filtering by type (todos / ingresos / egresos) is done client-side on the already-loaded list — no extra network call needed since the backend
  already returns all payments for the user in one request. Date range filtering is server-side: `applyDateRange()` updates the ViewModel state
  and re-triggers `load()` with the new params.

  State is managed via `MutableStateFlow<PaymentHistoryUiState>` collected with `collectAsStateWithLifecycle()`, consistent with the rest of the
  app. The ViewModel Factory receives `PaymentRepository` from `AppContainer`.

  ---

  ## API / Database Changes

  ### Endpoint used (read only)

  `GET /payments`

  | Parameter | Type | Required | Description |
  |---|---|---|---|
  | `startDate` | `String` (YYYY-MM-DD) | No | Filter payments on or after this date |
  | `endDate` | `String` (YYYY-MM-DD) | No | Filter payments on or before this date |

  ### Response model — `PaymentResponse`

  ```kotlin
  data class PaymentResponse(
      val idPayment: Int,
      val idContract: Int,
      val amount: Double,
      val paymentMethod: String,   // "transfer" | "cash" | "sinpe"
      val date: String,            // "YYYY-MM-DD"
      val type: String,            // "received" | "made"
      val receiptUrl: String?,
      val concept: String?         // job title
  )
```
  No database or schema changes. The endpoint already existed; this PR only adds the frontend integration.

  ---
  Testing Performed

  - [x] Feature tested manually
  - [x] Navigation tested — "Historial" link in student profile and "Historial de Pagos" button in company profile both navigate correctly; back
  button returns to profile
  - [x] Error handling tested — error state renders with retry button when request fails
  - [ ] Validation tested
  - [x] Backend integration tested — payments load and display correctly against a live backend
  - [x] No crashes detected

  Test Details

  - Student profile → "Historial" link → screen loads with received payments grouped by date.
  - Company profile → "Historial de Pagos" button → screen loads with made payments.
  - Filter chip "Ingresos" shows only type == "received" entries; "Egresos" shows only type == "made"; "Todos" resets.
  - Date range filter dialog opens, selecting start and end date re-fetches from backend with the correct query params.
  - "Limpiar" button in the dialog clears the date filter and re-fetches without params.
  - Balance card shows total received for students and total paid for companies.
  - Empty state ("Sin pagos registrados") renders when the filtered list is empty.
  - Bottom bar is hidden on the payment history screen, consistent with other sub-screens.

  ---
  Evidence

<img width="720" height="1604" alt="image" src="https://github.com/user-attachments/assets/1117fbd7-fd85-478a-bca7-9337b01952be" />

<img width="720" height="1604" alt="image" src="https://github.com/user-attachments/assets/743c1317-d7b6-4623-be67-d37a0843c3a8" />

<img width="720" height="1604" alt="image" src="https://github.com/user-attachments/assets/64be88d4-201e-4c71-a289-352139c7892e" />


  ---
  Notes

  The formatApplicationDate utility from JobFormatters.kt is reused for date display. Two new reusable components were added to ui/components:
  - PaymentCard — renders a single payment row with direction icon, concept, reference, amount and date. Can be reused in any future screen that
  needs to display a payment item.
  - DateRangePickerDialog — a generic date range picker dialog built on top of DatePickerField. Can be reused on any screen that needs date range
  filtering (contracts, applications, etc.).