### PR TITLE
feat: add student dashboard with personalized job recommendations

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/data/Job.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/Job.kt
@@ -15,5 +15,6 @@ data class Job(
     val startDate: String? = null,
     val endDate: String? = null,
     val deliverables: List<String>? = null,
+    val skillsRequired: List<String>? = null,
     val createdAt: String = ""
 )

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -54,6 +54,9 @@ interface ApiService {
     @GET("jobs")
     suspend fun getAllJobs(): Response<List<Job>>
 
+    @GET("jobs/recommended")
+    suspend fun getRecommendedJobs(): Response<List<Job>>
+
     @POST("jobs")
     suspend fun createJob(@Body request: CreateJobRequest): Response<CreateJobResponse>
   

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/JobRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/JobRepository.kt
@@ -27,6 +27,23 @@ class JobRepository(private val apiService: ApiService) {
         }
     }
 
+    suspend fun getRecommendedJobs(): ApiResult<List<Job>> {
+        return try {
+            val response = apiService.getRecommendedJobs()
+            if (response.isSuccessful && response.body() != null) {
+                ApiResult.Success(response.body()!!)
+            } else if (response.code() == 404) {
+                ApiResult.Error("Estudiante no encontrado", 404)
+            } else {
+                ApiResult.Error("Error al cargar recomendaciones (${response.code()})", response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado")
+        }
+    }
+
     suspend fun getJobs(): ApiResult<List<Job>> {
         return try {
             val response = apiService.getAllJobs()

--- a/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/moviles/jobmatch/navigation/AppNavHost.kt
@@ -31,6 +31,7 @@ import com.moviles.jobmatch.ui.screens.profile.StudentPublicProfileScreen
 import com.moviles.jobmatch.ui.screens.job.JobDetailScreen
 import com.moviles.jobmatch.ui.screens.job.JobsScreen
 import com.moviles.jobmatch.ui.screens.job.JobsViewModel
+import com.moviles.jobmatch.ui.screens.job.StudentDashboardScreen
 import com.moviles.jobmatch.ui.screens.login.LoginScreen
 import com.moviles.jobmatch.ui.screens.register.RegisterScreen
 import com.moviles.jobmatch.ui.screens.splash.SplashScreen
@@ -102,7 +103,7 @@ fun AppNavHost(modifier: Modifier = Modifier) {
                         val destination = if (AuthSession.isCompany)
                             AppDestinations.COMPANY_DASHBOARD
                         else
-                            AppDestinations.JOBS_EXPLORE
+                            AppDestinations.SEARCH_COMPANY
                         navController.navigate(destination) {
                             popUpTo(AppDestinations.LOGIN) { inclusive = true }
                         }
@@ -130,7 +131,15 @@ fun AppNavHost(modifier: Modifier = Modifier) {
             }
 
             composable(route = AppDestinations.SEARCH_COMPANY) {
-                PlaceholderScreen("Inicio")
+                if (AuthSession.isCompany) {
+                    PlaceholderScreen("Inicio")
+                } else {
+                    StudentDashboardScreen(
+                        onJobClick = { jobId ->
+                            navController.navigate(AppDestinations.jobDetailRoute(jobId))
+                        }
+                    )
+                }
             }
 
             composable(route = AppDestinations.JOBS_EXPLORE) {

--- a/app/src/main/java/com/moviles/jobmatch/ui/components/JobCard.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/components/JobCard.kt
@@ -3,6 +3,7 @@ package com.moviles.jobmatch.ui.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -19,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.moviles.jobmatch.data.Job
 import com.moviles.jobmatch.ui.theme.DarkBlue
+import com.moviles.jobmatch.ui.components.SkillChip
 
 @Composable
 fun JobCard(
@@ -88,6 +90,16 @@ fun JobCard(
                 InfoTag(text = "${job.startTime ?: ""} - ${job.endTime ?: ""}", icon = "🕒")
                 Spacer(modifier = Modifier.width(8.dp))
                 InfoTag(text = "Cerca de ti", icon = "📍")
+            }
+
+            if (!job.skillsRequired.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    job.skillsRequired.forEach { skill -> SkillChip(skill) }
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/job/StudentDashboardScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/job/StudentDashboardScreen.kt
@@ -1,0 +1,227 @@
+package com.moviles.jobmatch.ui.screens.job
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.WorkOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.moviles.jobmatch.ui.components.JobCard
+import com.moviles.jobmatch.ui.theme.DarkBlue
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StudentDashboardScreen(
+    onJobClick: (Int) -> Unit = {},
+    viewModel: StudentDashboardViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        "Panel Estudiante",
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 17.sp,
+                        color = Color(0xFF1A1A2E)
+                    )
+                },
+                actions = {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            Icons.Outlined.Notifications,
+                            contentDescription = "Notificaciones",
+                            tint = Color(0xFF555555)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color.White)
+            )
+        },
+        containerColor = Color(0xFFF4F6FA)
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentPadding = PaddingValues(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(0.dp)
+        ) {
+            item {
+                StudentGreetingCard(
+                    name = uiState.studentName,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+            }
+
+            item {
+                Text(
+                    "Recomendados para ti",
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp,
+                    color = Color(0xFF1A1A2E)
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            when {
+                uiState.isLoading -> {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(32.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(color = DarkBlue)
+                        }
+                    }
+                }
+
+                uiState.errorMessage != null -> {
+                    item {
+                        RecommendedErrorCard(
+                            message = uiState.errorMessage!!,
+                            onRetry = viewModel::loadRecommended,
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                    }
+                }
+
+                uiState.recommendedJobs.isEmpty() -> {
+                    item {
+                        RecommendedEmptyCard(modifier = Modifier.padding(horizontal = 16.dp))
+                    }
+                }
+
+                else -> {
+                    items(uiState.recommendedJobs) { job ->
+                        JobCard(
+                            job = job,
+                            onSeeMoreClick = { onJobClick(job.idJob) }
+                        )
+                    }
+                }
+            }
+
+            item { Spacer(modifier = Modifier.height(80.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun StudentGreetingCard(name: String, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = DarkBlue),
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Text(
+                text = "¡Hola, ${name.substringBefore(" ")}!",
+                fontWeight = FontWeight.Bold,
+                fontSize = 22.sp,
+                color = Color.White
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Estos trabajos se adaptan a tu disponibilidad y habilidades.",
+                fontSize = 13.sp,
+                color = Color.White.copy(alpha = 0.80f),
+                lineHeight = 18.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecommendedEmptyCard(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(32.dp)
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                Icons.Outlined.WorkOff,
+                contentDescription = null,
+                tint = Color(0xFFBBBBBB),
+                modifier = Modifier.size(48.dp)
+            )
+            Text(
+                "Sin recomendaciones por ahora",
+                fontWeight = FontWeight.Medium,
+                color = Color.Gray,
+                fontSize = 14.sp
+            )
+            Text(
+                "Actualiza tu disponibilidad y habilidades para recibir ofertas personalizadas.",
+                fontSize = 12.sp,
+                color = Color(0xFF8A9BB0),
+                lineHeight = 17.sp,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecommendedErrorCard(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(24.dp)
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                message,
+                color = MaterialTheme.colorScheme.error,
+                fontSize = 13.sp,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+            Button(
+                onClick = onRetry,
+                colors = ButtonDefaults.buttonColors(containerColor = DarkBlue),
+                shape = RoundedCornerShape(10.dp)
+            ) {
+                Text("Reintentar")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/job/StudentDashboardViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/job/StudentDashboardViewModel.kt
@@ -1,0 +1,46 @@
+package com.moviles.jobmatch.ui.screens.job
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.moviles.jobmatch.data.AuthSession
+import com.moviles.jobmatch.data.Job
+import com.moviles.jobmatch.data.repository.ApiResult
+import com.moviles.jobmatch.data.repository.AppContainer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class StudentDashboardUiState(
+    val isLoading: Boolean = false,
+    val recommendedJobs: List<Job> = emptyList(),
+    val errorMessage: String? = null,
+    val studentName: String = ""
+)
+
+class StudentDashboardViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(StudentDashboardUiState())
+    val uiState: StateFlow<StudentDashboardUiState> = _uiState.asStateFlow()
+
+    init {
+        val name = AuthSession.currentUser?.fullName ?: "Estudiante"
+        _uiState.update { it.copy(studentName = name) }
+        loadRecommended()
+    }
+
+    fun loadRecommended() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            when (val result = AppContainer.jobRepository.getRecommendedJobs()) {
+                is ApiResult.Success -> _uiState.update {
+                    it.copy(isLoading = false, recommendedJobs = result.data)
+                }
+                is ApiResult.Error -> _uiState.update {
+                    it.copy(isLoading = false, errorMessage = result.message)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Adds a personalized "Panel Estudiante" home screen for student users (issue #13 frontend). Students now land on a dashboard after login that calls the existing GET /jobs/recommended backend endpoint and displays matched jobs in a "Recomendados para ti" section. Jobs are matched server-side based on the student's registered availability (fixed-time jobs) and skills (autonomous jobs). Also adds skillsRequired to the Job model so required skills are rendered as chips on each JobCard, making the profile–job match visible to the student.

---

## Related Issue

Closes #13 

---

## Changes Included

### Frontend / Mobile Changes

* [x] Added new screen(s)
* [x] Added ViewModel(s)
* [x] Added navigation
* [x] Added API integration
* [x] Added loading/error states
* [ ] Added validation
* [x] Updated UI components
* [ ] Other:

---

## Architecture

StudentDashboardScreen (SEARCH_COMPANY route, students only)
→ StudentDashboardViewModel (data class UiState, same pattern as CompanyDashboardViewModel)
→ JobRepository.getRecommendedJobs()   — GET /jobs/recommended (Student JWT)
→ AuthSession.currentUser?.fullName    — student name for greeting card
Filtering logic lives entirely on the backend (PR #82): fixed-time jobs match by DayOfWeek + time slot containment against the student's availability; autonomous jobs match by skill name overlap. The frontend only displays results.

---

## API / Database Changes

No new backend endpoints

---

## Testing Performed

* [x] Feature tested manually
* [x] Navigation tested
* [x] Error handling tested
* [x] Backend integration tested
* [x] No crashes detected

### Test Details

tudent login navigates directly to "Panel Estudiante" (Inicio tab)
Greeting card shows first name from AuthSession
Recommended jobs load from the real backend — no mock data
Jobs with skillsRequired show skill chips on the card; jobs without skills show the card unchanged
Empty state renders when no jobs match the student's profile
Error state renders with a retry button when the server is unreachable
"Trabajos" tab still shows the full explore/search screen (JobsScreen) unchanged
Job card tap navigates correctly to job detail screen

---

## Evidence

<img width="1200" height="1600" alt="image" src="https://github.com/user-attachments/assets/dab50ed5-bbc6-4e1b-9d71-5fbfb3fe4f3a" />

<img width="1200" height="1600" alt="image" src="https://github.com/user-attachments/assets/454124b1-f878-4ae3-9f1f-cb815da01c71" />


---

## Notes

Add any additional context, pending work, or important considerations here.
