### PR TITLE
feat: add received ratings section to student and company profiles

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/ApiService.kt
@@ -30,6 +30,7 @@ import com.moviles.jobmatch.data.remote.model.CreatePaymentRequest
 import com.moviles.jobmatch.data.remote.model.CreatePaymentResponse
 import com.moviles.jobmatch.data.remote.model.CreateRatingRequest
 import com.moviles.jobmatch.data.remote.model.RatingResponse
+import com.moviles.jobmatch.data.remote.model.ReceivedRatingResponse
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -118,6 +119,9 @@ interface ApiService {
 
     @POST("ratings")
     suspend fun submitRating(@Body request: CreateRatingRequest): Response<RatingResponse>
+
+    @GET("ratings/me")
+    suspend fun getMyRatings(): Response<List<ReceivedRatingResponse>>
 
     @GET("payments")
     suspend fun getPaymentHistory(

--- a/app/src/main/java/com/moviles/jobmatch/data/remote/model/RatingModels.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/remote/model/RatingModels.kt
@@ -14,3 +14,13 @@ data class RatingResponse(
     val comment: String?,
     val createdAt: String
 )
+
+data class ReceivedRatingResponse(
+    val idRating: Int,
+    val idContract: Int,
+    val raterName: String,
+    val jobTitle: String,
+    val stars: Int,
+    val comment: String?,
+    val createdAt: String
+)

--- a/app/src/main/java/com/moviles/jobmatch/data/repository/RatingRepository.kt
+++ b/app/src/main/java/com/moviles/jobmatch/data/repository/RatingRepository.kt
@@ -3,6 +3,7 @@ package com.moviles.jobmatch.data.repository
 import com.moviles.jobmatch.data.remote.ApiService
 import com.moviles.jobmatch.data.remote.model.CreateRatingRequest
 import com.moviles.jobmatch.data.remote.model.RatingResponse
+import com.moviles.jobmatch.data.remote.model.ReceivedRatingResponse
 import java.io.IOException
 
 class RatingRepository(private val apiService: ApiService) {
@@ -23,6 +24,26 @@ class RatingRepository(private val apiService: ApiService) {
                     ApiResult.Error("Datos de calificación inválidos.", 400)
                 else ->
                     ApiResult.Error("Error al enviar calificación (${response.code()})", response.code())
+            }
+        } catch (e: IOException) {
+            ApiResult.Error("No se pudo conectar al servidor.")
+        } catch (e: Exception) {
+            ApiResult.Error(e.message ?: "Error inesperado.")
+        }
+    }
+
+    suspend fun getMyRatings(): ApiResult<List<ReceivedRatingResponse>> {
+        return try {
+            val response = apiService.getMyRatings()
+            when {
+                response.isSuccessful && response.body() != null ->
+                    ApiResult.Success(response.body()!!)
+                response.isSuccessful ->
+                    ApiResult.Success(emptyList())
+                response.code() == 401 ->
+                    ApiResult.Error("No autorizado.", 401)
+                else ->
+                    ApiResult.Error("Error al obtener calificaciones (${response.code()})", response.code())
             }
         } catch (e: IOException) {
             ApiResult.Error("No se pudo conectar al servidor.")

--- a/app/src/main/java/com/moviles/jobmatch/ui/components/ReceivedRatingCard.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/components/ReceivedRatingCard.kt
@@ -1,0 +1,83 @@
+package com.moviles.jobmatch.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.moviles.jobmatch.data.remote.model.ReceivedRatingResponse
+import com.moviles.jobmatch.ui.utils.formatApplicationDate
+
+@Composable
+fun ReceivedRatingCard(rating: ReceivedRatingResponse) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = rating.raterName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF1A2332),
+                    modifier = Modifier.weight(1f)
+                )
+                Row {
+                    repeat(5) { index ->
+                        Icon(
+                            imageVector = if (index < rating.stars) Icons.Filled.Star else Icons.Filled.StarBorder,
+                            contentDescription = null,
+                            tint = Color(0xFFFFC107),
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = rating.jobTitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = Color(0xFF5A6A7A)
+            )
+            if (!rating.comment.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = rating.comment,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFF1A2332)
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = formatApplicationDate(rating.createdAt),
+                style = MaterialTheme.typography.labelSmall,
+                color = Color(0xFF9AA5B4)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/components/ReceivedRatingsSection.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/components/ReceivedRatingsSection.kt
@@ -1,0 +1,65 @@
+package com.moviles.jobmatch.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.moviles.jobmatch.data.remote.model.ReceivedRatingResponse
+import com.moviles.jobmatch.ui.theme.DarkBlue
+
+@Composable
+fun ReceivedRatingsSection(
+    isLoading: Boolean,
+    error: String?,
+    ratings: List<ReceivedRatingResponse>
+) {
+    SectionHeader(title = "Calificaciones recibidas")
+    Spacer(modifier = Modifier.height(8.dp))
+    when {
+        isLoading -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    color = DarkBlue,
+                    modifier = Modifier.size(28.dp)
+                )
+            }
+        }
+        error != null -> {
+            Text(
+                text = error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+        ratings.isEmpty() -> {
+            Text(
+                text = "Aún no tienes calificaciones recibidas",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(0xFF9AA5B4)
+            )
+        }
+        else -> {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                ratings.forEach { rating ->
+                    ReceivedRatingCard(rating = rating)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
@@ -29,6 +29,7 @@ import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.*
 import com.moviles.jobmatch.ui.components.RatingDialog
+import com.moviles.jobmatch.ui.components.ReceivedRatingCard
 import com.moviles.jobmatch.ui.screens.profile.DeleteAccountViewModel
 import com.moviles.jobmatch.ui.theme.DarkBlue
 import com.moviles.jobmatch.ui.utils.formatApplicationDate
@@ -333,6 +334,51 @@ fun CompanyProfileContent(
                 }
                 Spacer(modifier = Modifier.height(16.dp))
             }
+        }
+
+        if (isOwnProfile) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                SectionHeader(title = "Calificaciones recibidas")
+                Spacer(modifier = Modifier.height(8.dp))
+                when {
+                    uiState.isLoadingRatings -> {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(64.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                color = DarkBlue,
+                                modifier = Modifier.size(28.dp)
+                            )
+                        }
+                    }
+                    uiState.ratingsError != null -> {
+                        Text(
+                            text = uiState.ratingsError!!,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                    uiState.receivedRatings.isEmpty() -> {
+                        Text(
+                            text = "Aún no tienes calificaciones recibidas",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color(0xFF9AA5B4)
+                        )
+                    }
+                    else -> {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            uiState.receivedRatings.forEach { rating ->
+                                ReceivedRatingCard(rating = rating)
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
         }
 
         if (isOwnProfile) {

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileScreen.kt
@@ -29,7 +29,7 @@ import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.*
 import com.moviles.jobmatch.ui.components.RatingDialog
-import com.moviles.jobmatch.ui.components.ReceivedRatingCard
+import com.moviles.jobmatch.ui.components.ReceivedRatingsSection
 import com.moviles.jobmatch.ui.screens.profile.DeleteAccountViewModel
 import com.moviles.jobmatch.ui.theme.DarkBlue
 import com.moviles.jobmatch.ui.utils.formatApplicationDate
@@ -338,44 +338,11 @@ fun CompanyProfileContent(
 
         if (isOwnProfile) {
             Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                SectionHeader(title = "Calificaciones recibidas")
-                Spacer(modifier = Modifier.height(8.dp))
-                when {
-                    uiState.isLoadingRatings -> {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(64.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            CircularProgressIndicator(
-                                color = DarkBlue,
-                                modifier = Modifier.size(28.dp)
-                            )
-                        }
-                    }
-                    uiState.ratingsError != null -> {
-                        Text(
-                            text = uiState.ratingsError!!,
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                    }
-                    uiState.receivedRatings.isEmpty() -> {
-                        Text(
-                            text = "Aún no tienes calificaciones recibidas",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = Color(0xFF9AA5B4)
-                        )
-                    }
-                    else -> {
-                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            uiState.receivedRatings.forEach { rating ->
-                                ReceivedRatingCard(rating = rating)
-                            }
-                        }
-                    }
-                }
+                ReceivedRatingsSection(
+                    isLoading = uiState.isLoadingRatings,
+                    error = uiState.ratingsError,
+                    ratings = uiState.receivedRatings
+                )
             }
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/company/CompanyProfileViewModel.kt
@@ -6,6 +6,7 @@ import com.moviles.jobmatch.data.Company
 import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.remote.model.CreateRatingRequest
+import com.moviles.jobmatch.data.remote.model.ReceivedRatingResponse
 import com.moviles.jobmatch.data.repository.ApiResult
 import com.moviles.jobmatch.data.repository.AppContainer
 import kotlinx.coroutines.async
@@ -26,6 +27,9 @@ data class CompanyProfileUiState(
     val ratingLoadingIds: Set<Int> = emptySet(),
     val ratingSuccessIds: Set<Int> = emptySet(),
     val ratingErrors: Map<Int, String> = emptyMap(),
+    val receivedRatings: List<ReceivedRatingResponse> = emptyList(),
+    val isLoadingRatings: Boolean = false,
+    val ratingsError: String? = null,
     val contractsErrorMessage: String? = null,
     val errorMessage: String? = null
 )
@@ -36,10 +40,11 @@ class CompanyProfileViewModel : ViewModel() {
 
     fun loadCompanyProfile(companyId: String) {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, isLoadingContracts = true, errorMessage = null) }
+            _uiState.update { it.copy(isLoading = true, isLoadingContracts = true, isLoadingRatings = true, errorMessage = null) }
 
             val profileDeferred = async { AppContainer.companyRepository.getCompanyById(companyId) }
             val contractsDeferred = async { AppContainer.contractRepository.getCompanyContracts() }
+            val ratingsDeferred = async { AppContainer.ratingRepository.getMyRatings() }
 
             when (val result = profileDeferred.await()) {
                 is ApiResult.Success -> _uiState.update { it.copy(isLoading = false, company = result.data) }
@@ -49,6 +54,11 @@ class CompanyProfileViewModel : ViewModel() {
             when (val result = contractsDeferred.await()) {
                 is ApiResult.Success -> _uiState.update { it.copy(isLoadingContracts = false, contracts = result.data) }
                 is ApiResult.Error -> _uiState.update { it.copy(isLoadingContracts = false, contractsErrorMessage = result.message) }
+            }
+
+            when (val result = ratingsDeferred.await()) {
+                is ApiResult.Success -> _uiState.update { it.copy(isLoadingRatings = false, receivedRatings = result.data) }
+                is ApiResult.Error -> _uiState.update { it.copy(isLoadingRatings = false, ratingsError = result.message) }
             }
         }
     }

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -64,6 +64,7 @@ import com.moviles.jobmatch.ui.components.DayAvailabilitySelector
 import com.moviles.jobmatch.ui.components.DeleteAccountDialog
 import com.moviles.jobmatch.ui.components.InfoRow
 import com.moviles.jobmatch.ui.components.RatingDialog
+import com.moviles.jobmatch.ui.components.ReceivedRatingCard
 import com.moviles.jobmatch.ui.components.JobMatchTopBar
 import com.moviles.jobmatch.ui.components.SectionHeader
 import com.moviles.jobmatch.ui.components.SkillChip
@@ -414,6 +415,50 @@ fun StudentProfileScreen(
                         }
                         Spacer(modifier = Modifier.height(16.dp))
                     }
+
+                    // --- Calificaciones recibidas ---
+                    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                        SectionHeader(title = "Calificaciones recibidas")
+                        Spacer(modifier = Modifier.height(8.dp))
+                        when {
+                            uiState.isLoadingRatings -> {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(64.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator(
+                                        color = DarkBlue,
+                                        modifier = Modifier.size(28.dp)
+                                    )
+                                }
+                            }
+                            uiState.ratingsError != null -> {
+                                Text(
+                                    text = uiState.ratingsError!!,
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                            uiState.receivedRatings.isEmpty() -> {
+                                Text(
+                                    text = "Aún no tienes calificaciones recibidas",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color(0xFF9AA5B4)
+                                )
+                            }
+                            else -> {
+                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    uiState.receivedRatings.forEach { rating ->
+                                        ReceivedRatingCard(rating = rating)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
 
                     // --- Footer ---
                     Column(modifier = Modifier.padding(horizontal = 16.dp)) {

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -64,7 +64,7 @@ import com.moviles.jobmatch.ui.components.DayAvailabilitySelector
 import com.moviles.jobmatch.ui.components.DeleteAccountDialog
 import com.moviles.jobmatch.ui.components.InfoRow
 import com.moviles.jobmatch.ui.components.RatingDialog
-import com.moviles.jobmatch.ui.components.ReceivedRatingCard
+import com.moviles.jobmatch.ui.components.ReceivedRatingsSection
 import com.moviles.jobmatch.ui.components.JobMatchTopBar
 import com.moviles.jobmatch.ui.components.SectionHeader
 import com.moviles.jobmatch.ui.components.SkillChip
@@ -418,44 +418,11 @@ fun StudentProfileScreen(
 
                     // --- Calificaciones recibidas ---
                     Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                        SectionHeader(title = "Calificaciones recibidas")
-                        Spacer(modifier = Modifier.height(8.dp))
-                        when {
-                            uiState.isLoadingRatings -> {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(64.dp),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    CircularProgressIndicator(
-                                        color = DarkBlue,
-                                        modifier = Modifier.size(28.dp)
-                                    )
-                                }
-                            }
-                            uiState.ratingsError != null -> {
-                                Text(
-                                    text = uiState.ratingsError!!,
-                                    color = MaterialTheme.colorScheme.error,
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                            }
-                            uiState.receivedRatings.isEmpty() -> {
-                                Text(
-                                    text = "Aún no tienes calificaciones recibidas",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = Color(0xFF9AA5B4)
-                                )
-                            }
-                            else -> {
-                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    uiState.receivedRatings.forEach { rating ->
-                                        ReceivedRatingCard(rating = rating)
-                                    }
-                                }
-                            }
-                        }
+                        ReceivedRatingsSection(
+                            isLoading = uiState.isLoadingRatings,
+                            error = uiState.ratingsError,
+                            ratings = uiState.receivedRatings
+                        )
                     }
 
                     Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileViewModel.kt
@@ -8,6 +8,7 @@ import com.moviles.jobmatch.data.remote.model.ContractDetailResponse
 import com.moviles.jobmatch.data.remote.model.ContractListResponse
 import com.moviles.jobmatch.data.remote.model.StudentProfileResponse
 import com.moviles.jobmatch.data.remote.model.CreateRatingRequest
+import com.moviles.jobmatch.data.remote.model.ReceivedRatingResponse
 import com.moviles.jobmatch.data.repository.ApiResult
 import com.moviles.jobmatch.data.repository.ContractRepository
 import com.moviles.jobmatch.data.repository.RatingRepository
@@ -32,6 +33,9 @@ data class StudentProfileUiState(
     val ratingLoadingIds: Set<Int> = emptySet(),
     val ratingSuccessIds: Set<Int> = emptySet(),
     val ratingErrors: Map<Int, String> = emptyMap(),
+    val receivedRatings: List<ReceivedRatingResponse> = emptyList(),
+    val isLoadingRatings: Boolean = false,
+    val ratingsError: String? = null,
     val contractsErrorMessage: String? = null,
     val errorMessage: String? = null
 )
@@ -52,10 +56,11 @@ class StudentProfileViewModel(
     fun loadProfile() {
         val studentId = AuthSession.currentUser?.userId ?: return
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, isLoadingContracts = true, errorMessage = null) }
+            _uiState.update { it.copy(isLoading = true, isLoadingContracts = true, isLoadingRatings = true, errorMessage = null) }
 
             val profileDeferred = async { studentRepository.getStudentProfile(studentId) }
             val contractsDeferred = async { contractRepository.getStudentContracts() }
+            val ratingsDeferred = async { ratingRepository.getMyRatings() }
 
             when (val result = profileDeferred.await()) {
                 is ApiResult.Success ->
@@ -69,6 +74,13 @@ class StudentProfileViewModel(
                     _uiState.update { it.copy(isLoadingContracts = false, contracts = result.data) }
                 is ApiResult.Error ->
                     _uiState.update { it.copy(isLoadingContracts = false, contractsErrorMessage = result.message) }
+            }
+
+            when (val result = ratingsDeferred.await()) {
+                is ApiResult.Success ->
+                    _uiState.update { it.copy(isLoadingRatings = false, receivedRatings = result.data) }
+                is ApiResult.Error ->
+                    _uiState.update { it.copy(isLoadingRatings = false, ratingsError = result.message) }
             }
         }
     }


### PR DESCRIPTION
# Pull Request

## Description

Adds a "Calificaciones recibidas" (Received Ratings) section to both the Student and Company profile screens. Each user can now see all ratings they have received from others — students see ratings left by companies, and companies see ratings left by students. The section loads inline within the profile, showing the rater's name, job title, star rating, comment, and date for each entry.

---

## Changes Included:

### Frontend / Mobile Changes

* [ ] Added new screen(s)
* [ ] Added ViewModel(s)
* [ ] Added navigation
* [x] Added API integration
* [x] Added loading/error states
* [ ] Added validation
* [x] Updated UI components
* [x] Other: New reusable `ReceivedRatingCard` component; `ReceivedRatingResponse` model added

---

## Architecture

UI (ProfileScreen) → ViewModel → RatingRepository → ApiService → `GET /ratings/me`

Ratings are fetched in parallel with the profile and contracts using `async/await` inside `loadProfile()` / `loadCompanyProfile()`, following the exact same pattern already used for contracts. State is managed via `MutableStateFlow<UiState>` and collected with `collectAsStateWithLifecycle()`.

<img width="1200" height="1600" alt="image" src="https://github.com/user-attachments/assets/e5c27eda-86c6-410d-bf7b-6b344348444d" />


---

## API / Database Changes

Consumes the existing `GET /ratings/me` endpoint (implemented in backend PR #22).

**Response model added:** `ReceivedRatingResponse`
```json
{
  "idRating": 1,
  "idContract": 5,
  "raterName": "Empresa ABC",
  "jobTitle": "Diseñador UI",
  "stars": 4,
  "comment": "Excellent work.",
  "createdAt": "2026-06-18T10:00:00Z"
}


