### PR TITLE
fix: misc UI bugfixes (skill input, dead back button, broken Google l…

### DIFF
--- a/app/src/main/java/com/moviles/jobmatch/ui/components/TopBar.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/components/TopBar.kt
@@ -40,12 +40,14 @@ fun JobMatchTopBar(
             }
         },
         navigationIcon = {
-            IconButton(onClick = onBackPressed) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Volver",
-                    tint = Color.Black
-                )
+            if (showBackButton) {
+                IconButton(onClick = onBackPressed) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Volver",
+                        tint = Color.Black
+                    )
+                }
             }
         },
         actions = {

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/login/LoginScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/login/LoginScreen.kt
@@ -1,6 +1,5 @@
 package com.moviles.jobmatch.ui.screens.login
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -26,7 +25,6 @@ import androidx.compose.material.icons.filled.Work
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -40,7 +38,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -49,10 +46,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.moviles.jobmatch.R
 import com.moviles.jobmatch.data.repository.AppContainer
 import com.moviles.jobmatch.ui.components.JobMatchButton
-import com.moviles.jobmatch.ui.components.JobMatchOutlinedButton
 import com.moviles.jobmatch.ui.components.JobMatchTextField
 import com.moviles.jobmatch.ui.theme.Background
 import com.moviles.jobmatch.ui.theme.BottomNavUnselected
@@ -63,8 +58,7 @@ import com.moviles.jobmatch.ui.theme.StatusInactive
 fun LoginScreen(
     onLoginSuccess: () -> Unit = {},
     onNavigateToRegister: () -> Unit = {},
-    onNavigateToForgotPassword: () -> Unit = {},
-    onGoogleSignIn: () -> Unit = {}
+    onNavigateToForgotPassword: () -> Unit = {}
 ) {
     val loginViewModel: LoginViewModel = viewModel(
         factory = LoginViewModelFactory(AppContainer.authRepository)
@@ -128,38 +122,6 @@ fun LoginScreen(
             )
 
             Spacer(modifier = Modifier.height(32.dp))
-
-            // Botón Google
-            JobMatchOutlinedButton(
-                text = "Continuar con Google",
-                onClick = onGoogleSignIn,
-                leadingContent = {
-                    Image(
-                        painter = painterResource(R.drawable.ic_google),
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            // Divisor
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                HorizontalDivider(modifier = Modifier.weight(1f), color = Color.LightGray)
-                Text(
-                    text = "O USA TU CORREO",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = Color.Gray,
-                    modifier = Modifier.padding(horizontal = 16.dp)
-                )
-                HorizontalDivider(modifier = Modifier.weight(1f), color = Color.LightGray)
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
 
             // Campo correo
             JobMatchTextField(

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/SkillSelectionScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/SkillSelectionScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -29,7 +30,9 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
@@ -40,7 +43,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -106,6 +111,7 @@ fun SkillSelectionScreen(
         snackbarHostState = snackbarHostState,
         onBackPressed = onBackPressed,
         onToggleSkill = { viewModel.toggleSkill(it) },
+        onAddCustomSkill = { viewModel.addCustomSkill(it) },
         onSave = { viewModel.saveSkills(studentId) },
         onRetry = { viewModel.loadSkills() },
         onRemoveSkill = { skill ->
@@ -120,11 +126,14 @@ private fun SkillSelectionContent(
     snackbarHostState: SnackbarHostState,
     onBackPressed: () -> Unit,
     onToggleSkill: (String) -> Unit,
+    onAddCustomSkill: (String) -> Unit,
     onSave: () -> Unit,
     onRetry: () -> Unit,
     onRemoveSkill: (StudentSkillResponse) -> Unit
 ) {
     val expandedMap = remember { mutableStateMapOf<Char, Boolean>() }
+    var newSkillText by remember { mutableStateOf("") }
+    val customSkills = uiState.selectedSkills.filter { it !in uiState.skills }
 
     Scaffold(
         topBar = {
@@ -180,6 +189,55 @@ private fun SkillSelectionContent(
                                         onRemove = { onRemoveSkill(skill) }
                                     )
                                 }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // --- Agregar habilidad manual ---
+                Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    SectionHeader(title = "Agregar habilidad nueva")
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        OutlinedTextField(
+                            value = newSkillText,
+                            onValueChange = { newSkillText = it },
+                            placeholder = { Text("Ej: Adobe Illustrator") },
+                            singleLine = true,
+                            shape = RoundedCornerShape(12.dp),
+                            modifier = Modifier.weight(1f)
+                        )
+                        IconButton(
+                            onClick = {
+                                onAddCustomSkill(newSkillText)
+                                newSkillText = ""
+                            },
+                            enabled = newSkillText.isNotBlank()
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = "Agregar habilidad",
+                                tint = DarkBlue
+                            )
+                        }
+                    }
+                    if (customSkills.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            customSkills.forEach { skill ->
+                                CurrentSkillChip(
+                                    text = skill,
+                                    isRemoving = false,
+                                    onRemove = { onToggleSkill(skill) }
+                                )
                             }
                         }
                     }
@@ -426,6 +484,7 @@ private fun SkillSelectionScreenPreview() {
             snackbarHostState = snackbarHostState,
             onBackPressed = {},
             onToggleSkill = {},
+            onAddCustomSkill = {},
             onSave = {},
             onRetry = {},
             onRemoveSkill = {}

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/SkillSelectionViewModel.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/SkillSelectionViewModel.kt
@@ -60,6 +60,15 @@ class SkillSelectionViewModel(
         }
     }
 
+    fun addCustomSkill(name: String) {
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return
+        val currentNames = _uiState.value.currentSkills.map { it.skillName.lowercase() }
+        val alreadySelected = _uiState.value.selectedSkills.map { it.lowercase() }
+        if (trimmed.lowercase() in currentNames || trimmed.lowercase() in alreadySelected) return
+        _uiState.update { it.copy(selectedSkills = it.selectedSkills + trimmed, errorMessage = null) }
+    }
+
     fun saveSkills(studentId: String) {
         val toSave = _uiState.value.selectedSkills.toList()
         if (toSave.isEmpty()) return

--- a/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
+++ b/app/src/main/java/com/moviles/jobmatch/ui/screens/profile/StudentProfileScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.AlertDialog
@@ -507,30 +506,6 @@ fun StudentProfileScreen(
                             )
                             Spacer(modifier = Modifier.height(12.dp))
                         }
-                        OutlinedButton(
-                            onClick = {},
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(48.dp),
-                            shape = RoundedCornerShape(12.dp),
-                            border = BorderStroke(1.dp, DarkBlue),
-                            colors = ButtonDefaults.outlinedButtonColors(contentColor = DarkBlue)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Add,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = "Añadir Certificación o Título",
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = FontWeight.Medium
-                            )
-                        }
-
-                        Spacer(modifier = Modifier.height(8.dp))
-
                         OutlinedButton(
                             onClick = { showDeleteDialog = true },
                             modifier = Modifier


### PR DESCRIPTION
Description
Fixes for several broken/dead UI elements found during manual testing: students couldn't add custom skills, the "back" button on the profile screen did nothing, and the "Continuar con Google" login button was non-functional.

Changes
SkillSelectionScreen.kt / SkillSelectionViewModel.kt: added a text field + button so students can type and add a skill not in the existing catalog (backend already supported creating new skills on the fly, just had no UI for it)
TopBar.kt: fixed JobMatchTopBar ignoring the showBackButton flag — it always rendered the back arrow even when set to false, leaving a non-functional button visible on the student profile screen
LoginScreen.kt: removed the "Continuar con Google" button and the "O usa tu correo" divider (Google sign-in was never wired up, button did nothing)
StudentProfileScreen.kt: removed the "Añadir Certificación o Título" button (had no onClick logic, dead placeholder)